### PR TITLE
Copy BuildArch from subpackages

### DIFF
--- a/macros.lua
+++ b/macros.lua
@@ -165,7 +165,7 @@ function _python_emit_subpackages()
 
     local function ignore_line(line) end
 
-    local PROPERTY_COPY_UNMODIFIED = lookup_table { "Summary", "Version" }
+    local PROPERTY_COPY_UNMODIFIED = lookup_table { "Summary", "Version", "BuildArch" }
     local PROPERTY_COPY_MODIFIED = lookup_table {
         "Requires", "Provides",
         "Recommends", "Suggests",


### PR DESCRIPTION
If a python subpackage had "BuildArch: noarch" (as is usually done
for -doc subpackages), the generated subpackage didn't include that
line, so different architectures were used for python and python3
packages.