### PR TITLE
Further fixes for RPM 4.14

### DIFF
--- a/macros.lua
+++ b/macros.lua
@@ -386,12 +386,12 @@ function python_subpackages()
     rpm.define("python_flavor " .. original_flavor)
 end
 
-function python_exec(+)
+function python_exec(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-=)
     local args = rpm.expand("%**")
     print(rpm.expand("%{python_expand %__$python " .. args .. "}"))
 end
 
-function python_expand(+)
+function python_expand(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-=)
     -- force spec scan
     rpm.expand("%_python_macro_init")
     local args = rpm.expand("%**")
@@ -403,14 +403,14 @@ function python_expand(+)
     end
 end
 
-function python_build(+)
+function python_build(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-=)
     rpm.expand("%_python_macro_init")
     for _, python in ipairs(pythons) do
         print(rpm.expand("%" .. python .. "_build %**"))
     end
 end
 
-function python_install(+)
+function python_install(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-=)
     rpm.expand("%_python_macro_init")
     for _, python in ipairs(pythons) do
         print(rpm.expand("%" .. python .. "_install %**"))


### PR DESCRIPTION
RPM 4.14 became strict and no longer allows calling macros with unknown
parameters. Previous RPM versions had already printed this as warnings
in the build log, but this was easily missed.

Commit 0ee2f5 was only partially fixing the issues observed.