### PR TITLE
Add --ignore to pytest calls to ignore build directories.

### DIFF
--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -51,5 +51,5 @@
 
 ##### testing commands #####
 
-%pytest() %{python_expand PYTHONPATH=%{buildroot}%{$python_sitelib} $python -mpytest -v "%**"}
-%pytest_arch() %{python_expand PYTHONPATH=%{buildroot}%{$python_sitearch} $python -mpytest -v "%**"}
+%pytest() %{python_expand PYTHONPATH=%{buildroot}%{$python_sitelib} $python -mpytest --ignore=_build.python2 --ignore=_build.python3 --ignore=_build.pypy3 -v "%**"}
+%pytest_arch() %{python_expand PYTHONPATH=%{buildroot}%{$python_sitearch} $python -mpytest --ignore=_build.python2 --ignore=_build.python3 --ignore=_build.pypy3 -v "%**"}


### PR DESCRIPTION
Every use of single-spec macros build in the extra directory called ``_build.%{python_flavor}``. This change extends pytest call to ignore all of them when running the tests.