### PR TITLE
Add macro for disabling Python dist metadata dependency generator

### DIFF
--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -60,4 +60,10 @@
 # No such option: --strip-file-prefix %%{buildroot} 
 %pyproject_install(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua: local args = rpm.expand("%**") print(rpm.expand("%{python_expand $python -mpip install --root %{buildroot} --no-compile --no-deps  --progress-bar off *.whl " .. args .. "}")) }
 
+##### Python dependency generator macros #####
+
+%python_disable_dependency_generator() \
+%undefine __pythondist_requires \
+%{nil}
+
 #vi:tw=0


### PR DESCRIPTION
This macro is borrowed from Fedora to be able to optionally disable
the new dependency generator in RPM 4.15 that generates `pythonX.Ydist(M)`
requires.

This is mainly intended for cases where the metadata is flat out wrong/broken
or if the metadata does not map to the packaging granularity (that is,
a Python package has been split into several subpackages and dependencies
are split along with them).