### PR TITLE
Do not write .pyc files for tests

### DIFF
--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -109,8 +109,8 @@
 
 ##### Pytest macros #####
 
-%pytest_arch(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua: local args = rpm.expand("%**") print(rpm.expand("%{python_expand PYTHONPATH=$PYTHONPATH:%{buildroot}%{$python_sitearch} py.test-%{$python_bin_suffix} --ignore=_build.python2 --ignore=_build.python3 --ignore=_build.pypy3 -v " .. args .. "}")) }
-%pytest(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua: local args = rpm.expand("%**") print(rpm.expand("%{python_expand PYTHONPATH=$PYTHONPATH:%{buildroot}%{$python_sitelib} py.test-%{$python_bin_suffix} --ignore=_build.python2 --ignore=_build.python3 --ignore=_build.pypy3 -v " .. args .. "}")) }
+%pytest_arch(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua: local args = rpm.expand("%**") print(rpm.expand("%{python_expand PYTHONPATH=$PYTHONPATH:%{buildroot}%{$python_sitearch} PYTHONDONTWRITEBYTECODE=1 py.test-%{$python_bin_suffix} --ignore=_build.python2 --ignore=_build.python3 --ignore=_build.pypy3 -v " .. args .. "}")) }
+%pytest(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua: local args = rpm.expand("%**") print(rpm.expand("%{python_expand PYTHONPATH=$PYTHONPATH:%{buildroot}%{$python_sitelib} PYTHONDONTWRITEBYTECODE=1 py.test-%{$python_bin_suffix} --ignore=_build.python2 --ignore=_build.python3 --ignore=_build.pypy3 -v " .. args .. "}")) }
 
 ##### PEP-518 macros #####
 %pyproject_wheel(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua: local args = rpm.expand("%**") print(rpm.expand("%{python_expand $python -mpip wheel --no-deps %{?py_setup_args:--build-option %{py_setup_args}} --use-pep517 --no-build-isolation --progress-bar off --verbose . " .. args .. "}")) }


### PR DESCRIPTION
several packages did not build reproducibly because tests wrote
time-based .pyc files that differed for every build.

See https://reproducible-builds.org/ for why this matters.

One current example is our `python-enaml` Tumbleweed package.