### PR TITLE
Do not expand macros, just print them unexpanded

### DIFF
--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -111,13 +111,21 @@
 
 %pytest(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua:\
     local args = rpm.expand("%**"); \
-    local intro = "%{python_expand PYTHONPATH=$PYTHONPATH:%{buildroot}%{$python_sitelib} PYTHONDONTWRITEBYTECODE=1 "; \
+    local path = ""; \
+    if posix.getenv("PYTHONPATH") then \
+    path = path .. "$PYTHONPATH:"; \
+    end; \
+    local intro = "%{python_expand PYTHONPATH=" .. path .. "%{buildroot}%{$python_sitelib} PYTHONDONTWRITEBYTECODE=1 "; \
     intro = intro .. "pytest-%{$python_bin_suffix} --ignore=_build.python2 --ignore=_build.python3 --ignore=_build.pypy3 -v " \
     print(intro .. args .. "}") \
 }
 %pytest_arch(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua:\
     local args = rpm.expand("%**"); \
-    local intro = "%{python_expand PYTHONPATH=$PYTHONPATH:%{buildroot}%{$python_sitearch} PYTHONDONTWRITEBYTECODE=1 "; \
+    local path = ""; \
+    if posix.getenv("PYTHONPATH") then \
+    path = path .. "$PYTHONPATH:"; \
+    end; \
+    local intro = "%{python_expand PYTHONPATH=" .. path .. "%{buildroot}%{$python_sitearch} PYTHONDONTWRITEBYTECODE=1 "; \
     intro = intro .. "pytest-%{$python_bin_suffix} --ignore=_build.python2 --ignore=_build.python3 --ignore=_build.pypy3 -v "; \
     print(intro .. args .. "}") \
 }

--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -109,13 +109,32 @@
 
 ##### Pytest macros #####
 
-%pytest_arch(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua: local args = rpm.expand("%**") print(rpm.expand("%{python_expand PYTHONPATH=$PYTHONPATH:%{buildroot}%{$python_sitearch} PYTHONDONTWRITEBYTECODE=1 pytest-%{$python_bin_suffix} --ignore=_build.python2 --ignore=_build.python3 --ignore=_build.pypy3 -v " .. args .. "}")) }
-%pytest(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua: local args = rpm.expand("%**") print(rpm.expand("%{python_expand PYTHONPATH=$PYTHONPATH:%{buildroot}%{$python_sitelib} PYTHONDONTWRITEBYTECODE=1 pytest-%{$python_bin_suffix} --ignore=_build.python2 --ignore=_build.python3 --ignore=_build.pypy3 -v " .. args .. "}")) }
+%pytest(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua:\
+    local args = rpm.expand("%**"); \
+    local intro = "%{python_expand PYTHONPATH=$PYTHONPATH:%{buildroot}%{$python_sitelib} PYTHONDONTWRITEBYTECODE=1 "; \
+    intro = intro .. "pytest-%{$python_bin_suffix} --ignore=_build.python2 --ignore=_build.python3 --ignore=_build.pypy3 -v " \
+    print(intro .. args .. "}") \
+}
+%pytest_arch(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua:\
+    local args = rpm.expand("%**"); \
+    local intro = "%{python_expand PYTHONPATH=$PYTHONPATH:%{buildroot}%{$python_sitearch} PYTHONDONTWRITEBYTECODE=1 "; \
+    intro = intro .. "pytest-%{$python_bin_suffix} --ignore=_build.python2 --ignore=_build.python3 --ignore=_build.pypy3 -v "; \
+    print(intro .. args .. "}") \
+}
 
 ##### PEP-518 macros #####
-%pyproject_wheel(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua: local args = rpm.expand("%**") print(rpm.expand("%{python_expand $python -mpip wheel --no-deps %{?py_setup_args:--build-option %{py_setup_args}} --use-pep517 --no-build-isolation --progress-bar off --verbose . " .. args .. "}")) }
+%pyproject_wheel(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua:\
+    local args = rpm.expand("%**"); \
+    local intro = "%{python_expand $python -mpip wheel --no-deps %{?py_setup_args:--build-option %{py_setup_args}}"; \
+    intro = intro .. " --use-pep517 --no-build-isolation --progress-bar off --verbose . "; \
+    print(intro .. args .. "}") \
+}
 
 # No such option: --strip-file-prefix %%{buildroot} 
-%pyproject_install(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua: local args = rpm.expand("%**") print(rpm.expand("%{python_expand $python -mpip install --root %{buildroot} --no-compile --no-deps  --progress-bar off *.whl " .. args .. "}")) }
+%pyproject_install(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua:\
+    local args = rpm.expand("%**"); \
+    local intro = "%{python_expand $python -mpip install --root %{buildroot} --no-compile --no-deps  --progress-bar off *.whl "; \
+    print(intro .. args .. "}") \
+}
 
-#vi:tw=0
+#vi:tw=0 nowrap:


### PR DESCRIPTION
(for %pytest* and %pyproject* macros)

Also, write them in multiline more readable manner.

If anybody refactor shared code to special function/macro, I am all ears.