### PR TITLE
let the shell expand PYTHONPATH in pytest macros

### DIFF
--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -119,7 +119,7 @@
 %pytest_arch(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua:\
     local args = rpm.expand("%**"); \
     local broot = rpm.expand("%buildroot"); \
-    local intro = "%{python_expand ${PYTHONPATH:+$PYTHONPATH:}" .. broot .. "%{$python_sitearch} PYTHONDONTWRITEBYTECODE=1 "; \
+    local intro = "%{python_expand PYTHONPATH=${PYTHONPATH:+$PYTHONPATH:}" .. broot .. "%{$python_sitearch} PYTHONDONTWRITEBYTECODE=1 "; \
     intro = intro .. "pytest-%{$python_bin_suffix} --ignore=_build.python2 --ignore=_build.python3 --ignore=_build.pypy3 -v "; \
     print(rpm.expand(intro .. args .. "}")) \
 }

--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -111,23 +111,15 @@
 
 %pytest(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua:\
     local args = rpm.expand("%**"); \
-    local path = ""; \
-    if posix.getenv("PYTHONPATH") then \
-    path = path .. "$PYTHONPATH:"; \
-    end; \
     local broot = rpm.expand("%buildroot"); \
-    local intro = "%{python_expand PYTHONPATH=" .. path .. broot .. "%{$python_sitelib} PYTHONDONTWRITEBYTECODE=1 "; \
+    local intro = "%{python_expand PYTHONPATH=${PYTHONPATH:+$PYTHONPATH:}" .. broot .. "%{$python_sitelib} PYTHONDONTWRITEBYTECODE=1 "; \
     intro = intro .. "pytest-%{$python_bin_suffix} --ignore=_build.python2 --ignore=_build.python3 --ignore=_build.pypy3 -v "; \
     print(rpm.expand(intro .. args .. "}")) \
 }
 %pytest_arch(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua:\
     local args = rpm.expand("%**"); \
-    local path = ""; \
-    if posix.getenv("PYTHONPATH") then \
-    path = path .. "$PYTHONPATH:"; \
-    end; \
     local broot = rpm.expand("%buildroot"); \
-    local intro = "%{python_expand PYTHONPATH=" .. path .. broot .. "%{$python_sitearch} PYTHONDONTWRITEBYTECODE=1 "; \
+    local intro = "%{python_expand ${PYTHONPATH:+$PYTHONPATH:}" .. broot .. "%{$python_sitearch} PYTHONDONTWRITEBYTECODE=1 "; \
     intro = intro .. "pytest-%{$python_bin_suffix} --ignore=_build.python2 --ignore=_build.python3 --ignore=_build.pypy3 -v "; \
     print(rpm.expand(intro .. args .. "}")) \
 }


### PR DESCRIPTION
Expanding PYTHONPATH by the Lua macro is too early, PYTHONPATH set during `%check` before calling `%pytest*` is overridden as in the posted log from python-numpy https://github.com/openSUSE/python-rpm-macros/issues/48#issuecomment-648104068

Fixes #48 a bit more