### PR TITLE
add blank line between pytest and pytest_arch

### DIFF
--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -116,6 +116,7 @@
     intro = intro .. "pytest-%{$python_bin_suffix} --ignore=_build.python2 --ignore=_build.python3 --ignore=_build.pypy3 -v "; \
     print(rpm.expand(intro .. args .. "}")) \
 }
+
 %pytest_arch(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua:\
     local args = rpm.expand("%**"); \
     local broot = rpm.expand("%buildroot"); \


### PR DESCRIPTION
Leap 15.1 and 15.2 repositories fail to expand the pytest_arch. I am not entirely sure why, but adding the blank line seems to help.

Compare python-numpy in [devel:languages:python:numeric](https://build.opensuse.org/package/show/devel:languages:python:numeric/python-numpy) with [home:bnavigator:branches:devel:languages:python:numeric](https://build.opensuse.org/package/show/home:bnavigator:branches:devel:languages:python:numeric/python-numpy) where I have branched python-rpm-macros into the project and [applied the patch](https://build.opensuse.org/package/rdiff/home:bnavigator:branches:devel:languages:python:numeric/python-rpm-macros?opackage=python-rpm-macros&oproject=devel%3Alanguages%3Apython%3AFactory&rev=2).
