### PR TITLE
Add pyunittest and pyunittest_arch macros

### DIFF
--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -107,6 +107,22 @@
 %global __pythondist_requires %{_rpmconfigdir}/pythondistdeps.py --requires \
 %{nil}
 
+##### Python Unittest macros #####
+
+%pyunittest(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua:\
+    local args = rpm.expand("%**"); \
+    local broot = rpm.expand("%buildroot"); \
+    local intro = "%{python_expand PYTHONPATH=${PYTHONPATH:+$PYTHONPATH:}" .. broot .. "%{$python_sitelib} PYTHONDONTWRITEBYTECODE=1 -m unittest -v "; \
+    print(rpm.expand(intro .. args .. "}")) \
+}
+
+%pyunittest_arch(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua:\
+    local args = rpm.expand("%**"); \
+    local broot = rpm.expand("%buildroot"); \
+    local intro = "%{python_expand PYTHONPATH=${PYTHONPATH:+$PYTHONPATH:}" .. broot .. "%{$python_sitearch} PYTHONDONTWRITEBYTECODE=1 -m unittest -v "; \
+    print(rpm.expand(intro .. args .. "}")) \
+}
+
 ##### Pytest macros #####
 
 %pytest(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua:\


### PR DESCRIPTION
With the firm deprecation of python setup.py test, a lot of packages are
moving to calling python -m unittest for their testsuite, to avoid a lot
of duplicated and slightly different code, add two macros for ease of
calling.