### PR TITLE
Drop -v from the pyunittest macros

### DIFF
--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -112,14 +112,14 @@
 %pyunittest(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua:\
     local args = rpm.expand("%**"); \
     local broot = rpm.expand("%buildroot"); \
-    local intro = "%{python_expand PYTHONPATH=${PYTHONPATH:+$PYTHONPATH:}" .. broot .. "%{$python_sitelib} PYTHONDONTWRITEBYTECODE=1 $python -m unittest -v "; \
+    local intro = "%{python_expand PYTHONPATH=${PYTHONPATH:+$PYTHONPATH:}" .. broot .. "%{$python_sitelib} PYTHONDONTWRITEBYTECODE=1 $python -m unittest "; \
     print(rpm.expand(intro .. args .. "}")) \
 }
 
 %pyunittest_arch(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua:\
     local args = rpm.expand("%**"); \
     local broot = rpm.expand("%buildroot"); \
-    local intro = "%{python_expand PYTHONPATH=${PYTHONPATH:+$PYTHONPATH:}" .. broot .. "%{$python_sitearch} PYTHONDONTWRITEBYTECODE=1 $python -m unittest -v "; \
+    local intro = "%{python_expand PYTHONPATH=${PYTHONPATH:+$PYTHONPATH:}" .. broot .. "%{$python_sitearch} PYTHONDONTWRITEBYTECODE=1 $python -m unittest "; \
     print(rpm.expand(intro .. args .. "}")) \
 }
 


### PR DESCRIPTION
Including -v in the pyunittest macros makes for lovely test output, but
it also makes macro expansion fraught with peril, so drop it.

Fixes #57