### PR TITLE
disable pip version check: no connection to pypi.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,10 @@ subpackages of that particular flavor.
 
 * __`%python_install`__ expands to distutils/setuptools install instructions for all flavors.
 
-* __`%pyproject_wheel`__ expands to PEP517 build instructions for all flavors and creates wheels.
+* __`%pyproject_wheel`__ expands to 
+[PEP517](https://www.python.org/dev/peps/pep-0517)/[PEP518](https://www.python.org/dev/peps/pep-0518/)
+build instructions for all flavors and creates wheels. This is useful if the package has a 
+``pyproject.toml`` file but no ``setup.py``
 
 * __`%pyproject_install`__ expands to install instructions for all flavors to install the created wheels.
 

--- a/README.md
+++ b/README.md
@@ -105,9 +105,13 @@ subpackages of that particular flavor.
 * __`%pycache_only`__: applies the contents of the line only to subpackages of flavors that generate
 `__pycache__` directories. Useful in filelists: `%pycache_only %{python_sitelib}/__pycache__/*`
 
-* __`%python_build`__ expands to build instructions for all flavors.
+* __`%python_build`__ expands to distutils/setuptools build instructions for all flavors.
 
-* __`%python_install`__ expands to install instructions for all flavors.
+* __`%python_install`__ expands to distutils/setuptools install instructions for all flavors.
+
+* __`%pyproject_wheel`__ expands to PEP517 build instructions for all flavors and creates wheels.
+
+* __`%pyproject_install`__ expands to install instructions for all flavors to install the created wheels.
 
 * __`%python_exec something.py`__ expands to `$flavor something.py` for all flavors, and moves around
 the distutils-generated `build` directory so that you are never running `python2` script with a

--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -145,7 +145,7 @@
 %pyproject_wheel(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua:\
     local args = rpm.expand("%**"); \
     local intro = "%{python_expand $python -mpip wheel --no-deps %{?py_setup_args:--build-option %{py_setup_args}}"; \
-    intro = intro .. " --use-pep517 --no-build-isolation --progress-bar off --verbose . "; \
+    intro = intro .. " --disable-pip-version-check --use-pep517 --no-build-isolation --progress-bar off --verbose . "; \
     print(rpm.expand(intro .. args .. "}")) \
 }
 
@@ -153,7 +153,7 @@
 %pyproject_install(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua:\
     local args = rpm.expand("%**"); \
     local broot = rpm.expand("--root %buildroot"); \
-    local intro = "%{python_expand $python -mpip install " .. broot .. " --no-compile --no-deps  --progress-bar off *.whl "; \
+    local intro = "%{python_expand $python -mpip install " .. broot .. " --disable-pip-version-check --no-compile --no-deps  --progress-bar off *.whl "; \
     print(rpm.expand(intro .. args .. "}")) \
 }
 


### PR DESCRIPTION
This removes the attempt of pip to check for new versions and gets rid of the warning message saying so.

```
[    4s] 1 location(s) to search for versions of pip:
[    4s] * https://pypi.org/simple/pip/
[    4s] Fetching project page and analyzing links: https://pypi.org/simple/pip/
[    4s] Getting page https://pypi.org/simple/pip/
[    4s] Found index url https://pypi.org/simple
[    4s] Getting credentials from keyring for https://pypi.org/simple
[    4s] Getting credentials from keyring for pypi.org
[    4s] Looking up "https://pypi.org/simple/pip/" in the cache
[    4s] Request header has "max_age" as 0, cache bypassed
[    4s] Starting new HTTPS connection (1): pypi.org:443
[    4s] Could not fetch URL https://pypi.org/simple/pip/: connection error: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /simple/pip/ (Caused by NewConnectionError('<pip._vendor.urllib3.connection.VerifiedHTTPSConnection object at 0x7f65c225fd90>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution')) - skipping
[    4s] Given no hashes to check 0 links for project 'pip': discarding no candidates
```