### PR TITLE
add python_compileall macro and use it in pyproject_install

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ expands to:
 `python3 generatefile.py %python3_bin_suffix`
 etc.
 
+* __`%python_compileall`__ precompiles all python macros in `%{python_sitelib}` and `%{python_sitearch}`
+for all flavors. Generally Python 2 create `.pyc` files directly in the script directories, while
+newer flavors generate `__pycache__` directories.
+
 * __`%pytest`__ runs `pytest` in all flavors with appropriate environmental variables
 (namely, it sets `$PYTHONPATH` to ``%{python_sitelib}``). All paramteres to this macro are
 passed without change to the pytest command. Explicit `BuildRequires` on `%{python_module pytest}`

--- a/README.md
+++ b/README.md
@@ -122,9 +122,10 @@ expands to:
 `python3 generatefile.py %python3_bin_suffix`
 etc.
 
-* __`%python_compileall`__ precompiles all python macros in `%{python_sitelib}` and `%{python_sitearch}`
-for all flavors. Generally Python 2 create `.pyc` files directly in the script directories, while
-newer flavors generate `__pycache__` directories.
+* __`%python_compileall`__ precompiles all python source files in `%{python_sitelib}` and `%{python_sitearch}`
+for all flavors. Generally Python 2 creates the cached byte-code `.pyc` files directly in the script directories, while
+newer flavors generate `__pycache__` directories. Use this if you have modified the source files in `%buildroot` after
+`%python_install` or `%pyproject_install` has compiled the files the first time.
 
 * __`%pytest`__ runs `pytest` in all flavors with appropriate environmental variables
 (namely, it sets `$PYTHONPATH` to ``%{python_sitelib}``). All paramteres to this macro are

--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -163,6 +163,7 @@
 %python_compileall \
 %{python_expand for d in %{buildroot}%{$python_sitelib} %{buildroot}%{$python_sitearch}; do \
   if [ -d $d ]; then \
+    find $d -name '*.pyc' -delete; \
     $python -m compileall $d; \
     $python -O -m compileall $d; \
   fi; \

--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -155,6 +155,19 @@
     local broot = rpm.expand("--root %buildroot"); \
     local intro = "%{python_expand $python -mpip install " .. broot .. " --no-compile --no-deps  --progress-bar off *.whl "; \
     print(rpm.expand(intro .. args .. "}")) \
+    print(rpm.expand("%python_compileall"))
 }
+
+##### Precompile scripts macro #####
+
+%python_compileall \
+%{python_expand for d in %{buildroot}%{$python_sitelib} %{buildroot}%{$python_sitearch}; do \
+  if [ -d $d ]; then \
+    $python -m compileall $d; \
+    $python -O -m compileall $d; \
+  fi; \
+done \   
+} \
+%{nil}
 
 #vi:tw=0 nowrap:

--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -169,5 +169,3 @@
 done \   
 } \
 %{nil}
-
-#vi:tw=0 nowrap:


### PR DESCRIPTION
- Closes #9
- Closes #35
- Closes #41 (possibly)
- Restores the compilation for `%pyproject_install` removed by #37