### PR TITLE
fix whitespace after escape in compileall macro

### DIFF
--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -167,6 +167,7 @@
     $python -m compileall $d; \
     $python -O -m compileall $d; \
   fi; \
-done \   
+done \
 } \
 %{nil}
+


### PR DESCRIPTION
Fixes #62 (https://github.com/openSUSE/python-rpm-macros/pull/60#issuecomment-710102219)

Works in https://build.opensuse.org/package/show/home:bnavigator:branches:devel:languages:python:Factory/python-rpm-macros