### PR TITLE
Prepare for multiple python3 flavors

### DIFF
--- a/flavor.in
+++ b/flavor.in
@@ -1,17 +1,19 @@
 ##### macro definitions for flavor "#FLAVOR#" #####
 
-%__#FLAVOR#               /usr/bin/#FLAVOR#
-
 %#FLAVOR#_shbang_opts     %py_shbang_opts
 
-%#FLAVOR#_prefix          #FLAVOR#
-%#FLAVOR#_sitelib         %{_python_sysconfig_path #FLAVOR# purelib}
-%#FLAVOR#_sitearch        %{_python_sysconfig_path #FLAVOR# platlib}
-%#FLAVOR#_version         %{_python_sysconfig_var #FLAVOR# py_version_short}
-%#FLAVOR#_version_nodots  %{_python_sysconfig_var #FLAVOR# py_version_nodot}
+%__#FLAVOR#               /usr/bin/%{lua: print((string.gsub("#FLAVOR#", "(%w+%d)(%d)", "%1.%2")))}
 
-%#FLAVOR#_sysconfig_path() %{_rec_macro_helper}%{lua:call_sysconfig("path", "#FLAVOR#")}
-%#FLAVOR#_sysconfig_var()  %{_rec_macro_helper}%{lua:call_sysconfig("var", "#FLAVOR#")}
+%#FLAVOR#_prefix          #FLAVOR#
+%#FLAVOR#_sitelib         %{_python_sysconfig_path %__#FLAVOR# purelib}
+%#FLAVOR#_sitearch        %{_python_sysconfig_path %__#FLAVOR# platlib}
+%#FLAVOR#_version         %{_python_sysconfig_var  %__#FLAVOR# py_version_short}
+%#FLAVOR#_version_nodots  %{_python_sysconfig_var  %__#FLAVOR# py_version_nodot}
+
+%#FLAVOR#_bin_suffix      %{?!_#FLAVOR#_bin_suffix:%#FLAVOR#_version}%{?_#FLAVOR#_bin_suffix}
+
+%#FLAVOR#_sysconfig_path() %{_rec_macro_helper}%{lua:call_sysconfig("path", rpm.expand("%__#FLAVOR#"))}
+%#FLAVOR#_sysconfig_var()  %{_rec_macro_helper}%{lua:call_sysconfig("var", rpm.expand("%__#FLAVOR#"))}
 
 %if#FLAVOR#      %if "%{python_flavor}" == "#FLAVOR#"
 

--- a/macros.lua
+++ b/macros.lua
@@ -398,6 +398,9 @@ function python_expand(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123
     for _, python in ipairs(pythons) do
         print(rpm.expand("%{_python_use_flavor " .. python .. "}\n"))
         local cmd = replace_macros(args, python)
+        -- when used as call of the executable
+        cmd = cmd:gsub("$python%f[%s]", rpm.expand("%__" .. python))
+        -- when used as flavor expansion for a custom macro
         cmd = cmd:gsub("$python", python)
         print(rpm.expand(cmd .. "\n"))
     end

--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -24,24 +24,23 @@
 %py_setup setup.py
 %py_shbang_opts -s
 
-##### binary suffixes for flavors #####
+##### non-standard binary suffixes for flavors #####
 
-%python2_bin_suffix %python2_version
-%python3_bin_suffix %python3_version
-%pypy3_bin_suffix   pp%{pypy3_version}
+%_pypy3_bin_suffix   pp%{pypy3_version}
+
 
 ##### preferred configuration #####
 
-%python_sitelib          %{_python_sysconfig_path %python_flavor purelib}
-%python_sitearch         %{_python_sysconfig_path %python_flavor platlib}
-%python_version          %{_python_sysconfig_var  %python_flavor py_version_short}
-%python_version_nodots   %{_python_sysconfig_var  %python_flavor py_version_nodot}
+%python_sitelib          %{_python_sysconfig_path %{__%python_flavor} purelib}
+%python_sitearch         %{_python_sysconfig_path %{__%python_flavor} platlib}
+%python_version          %{_python_sysconfig_var  %{__%python_flavor} py_version_short}
+%python_version_nodots   %{_python_sysconfig_var  %{__%python_flavor} py_version_nodot}
 
 %python_prefix                  %{_rec_macro_helper}%{lua:expand_macro("prefix")}
 %python_bin_suffix              %{_rec_macro_helper}%{lua:expand_macro("bin_suffix")}
 
-%python_sysconfig_path()        %{_rec_macro_helper}%{lua:call_sysconfig("path", "%python_flavor")}
-%python_sysconfig_var()         %{_rec_macro_helper}%{lua:call_sysconfig("var", "%python_flavor")}
+%python_sysconfig_path()        %{_rec_macro_helper}%{lua:call_sysconfig("path", "%{__%python_flavor}")}
+%python_sysconfig_var()         %{_rec_macro_helper}%{lua:call_sysconfig("var", "%{__%python_flavor}")}
 
 %python_alternative()           %{_rec_macro_helper}%{lua:expand_macro("alternative", "%**")}
 %python_install_alternative()   %{_rec_macro_helper}%{lua:expand_macro("install_alternative", "%**")}


### PR DESCRIPTION
This is the `multiple_flavors.patch` from https://build.opensuse.org/request/show/842974 without the actual activation of `python36` and `python38` flavor.

Based on @mcepl's original patch, fixed for the expansion of `$python` in `%python_expand` and the macros calling `sysconfig`.