### PR TITLE
more command delimiters for %python_expand

### DIFF
--- a/macros.lua
+++ b/macros.lua
@@ -399,7 +399,7 @@ function python_expand(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123
         print(rpm.expand("%{_python_use_flavor " .. python .. "}\n"))
         local cmd = replace_macros(args, python)
         -- when used as call of the executable
-        cmd = cmd:gsub("$python%f[%s]", rpm.expand("%__" .. python))
+        cmd = cmd:gsub("$python%f[%s\"\'\\%)&|;<>]", rpm.expand("%__" .. python))
         -- when used as flavor expansion for a custom macro
         cmd = cmd:gsub("$python", python)
         print(rpm.expand(cmd .. "\n"))


### PR DESCRIPTION
A fix for when people need the executable as argument and use constructions like  `--python="$python"` or other shell command delimiters directly after `$python` like in https://github.com/openSUSE/python-rpm-macros/issues/66#issuecomment-715609273