### PR TITLE
expand parameters for subpackage_only packages

### DIFF
--- a/macros.lua
+++ b/macros.lua
@@ -83,7 +83,9 @@ function python_subpackages()
     -- line processing functions
     local function print_altered(line)
         -- set %name macro to proper flavor-name
-        line = line:gsub("%%{?name}?", current_flavor .. "-" .. modname)
+        if not subpackage_only then
+            line = line:gsub("%%{?name}?", current_flavor .. "-" .. modname)
+        end
         -- print expanded
         print(rpm.expand(replace_macros(line, current_flavor)) .. "\n")
     end
@@ -158,7 +160,9 @@ function python_subpackages()
             print_altered(line)
         elseif PROPERTY_COPY_MODIFIED[property] then
             -- specifically handle %name macro before expansion
-            line = line:gsub("%%{?name}?", current_flavor .. "-" .. modname)
+            if not subpackage_only then
+                line = line:gsub("%%{?name}?", current_flavor .. "-" .. modname)
+            end
             -- convert value using the appropriate function
             if value:startswith("packageand") then
                 value = fix_packageand(value, flavor)

--- a/macros.lua
+++ b/macros.lua
@@ -343,20 +343,20 @@ function python_subpackages()
 
                 if KNOWN_SECTIONS[newsection] then
                     -- enter new section
-                    local submodname
-                    local subparam
                     local ignore_section = false
                     if subpackage_only then
                         ignore_section = true
                         if param then
+                            local subparam
                             if newsection == "files" then
-                                submodname, subparam = param:match("%%{python_files%s+(%S+)%s*(.*)}")
+                                subparam = param:match("%%{python_files%s+(.*)}")
                             else
-                                submodname, subparam = param:match("^%-n%s+%%{python_flavor}%-(%S+)%s*(.*)$")
+                                subparam = param:match("^%-n%s+%%{python_flavor}%-(.*)$")
                             end
-                            if submodname then
+                            if subparam then
+                                local submodname, subsubparam = rpm.expand(subparam):match("^(%S+)%s*(.*)$")
                                 modname = submodname
-                                param = subparam
+                                param = subsubparam
                                 ignore_section = false
                             end
                         end


### PR DESCRIPTION
To allow constructs like
```
%define python_subpackage_only 1

%package -n %{python_flavor}-%{name}

%files %{python_files %{name}}
```