### PR TITLE
Add default provider lines for more properties

### DIFF
--- a/macros.lua
+++ b/macros.lua
@@ -108,6 +108,9 @@ function python_subpackages()
         "Requires(pre):", "Requires(preun):", "Requires(post):", "Requires(postun):",
         "Requires(pretrans):", "Requires(posttrans):",
     }
+    local PROPERTY_COPY_DEFAULT_PROVIDER = lookup_table {
+        "Conflicts:", "Obsoletes:", "Provides:", "Supplements:", "Enhances:",
+    }
 
     local function process_package_line(line)
         -- This function processes lines like "Requires: something something".
@@ -159,14 +162,26 @@ function python_subpackages()
         elseif PROPERTY_COPY_MODIFIED[property] then
             -- specifically handle %name macro before expansion
             line = line:gsub("%%{?name}?", current_flavor .. "-" .. modname)
-            -- convert value using the appropriate function
-            if value:startswith("packageand") then
-                value = fix_packageand(value, flavor)
-            else
-                value = rename_package(value, flavor)
+            local function print_property_copy_modified(value)
+                -- convert value using the appropriate function
+                if value:startswith("packageand") then
+                    value = fix_packageand(value, flavor)
+                else
+                    value = rename_package(value, flavor)
+                end
+                -- rely on print_altered to perform expansion on the result
+                print_altered(string.format("%s %s", property, value))
             end
-            -- rely on print_altered to perform expansion on the result
-            print_altered(string.format("%s %s", property, value))
+            if PROPERTY_COPY_DEFAULT_PROVIDER[property] then
+                -- print renamed lines for all flavors which the current_flavor provides.
+                for iflavor in string.gmatch(rpm.expand("%{?" .. current_flavor .. "_provides}") .. " " .. current_flavor, "%S+" ) do
+                    current_flavor = iflavor -- make sure to process the main current_flavor last for final reset.
+                    print_property_copy_modified(value)
+                end
+            else
+                print_property_copy_modified(value)
+            end
+
         end
     end
 


### PR DESCRIPTION
The current unresolvables of `python3-dateutil` in Staging:N revealed that we also need to rewrite those properties to provide, obsolete, ... the 'python3-foo' packages.