### PR TITLE
Also rewrite subpackage_only default providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ main headers section.
 
 * __`%python_subpackage_only`__. Undefined by default. If you want to generate `<flavor>-modname`
 subpackages for a non-python main package, make sure to `%define python_subpackage_only 1` before
-`%python_subpackages` and use `-n %{python_flavor}-modname` for section headers.
+`%python_subpackages` and use `-n python-modname` for section headers (except for `%files`, see below).
 
 * __`%python_enable_dependency_generator`__ expands to a define to enable automatic requires generation
 of Python module dependencies using egg-info/dist-info metadata. This should go above the

--- a/macros.lua
+++ b/macros.lua
@@ -326,7 +326,7 @@ function python_subpackages()
         current_flavor = python
 
         -- rescan spec for each flavor
-        if not is_current_flavor then
+        if not is_current_flavor or subpackage_only then
             local spec, err = io.open(specpath, "r")
             if err then print ("could not find spec file at path: " .. specpath) return end
 
@@ -370,7 +370,7 @@ function python_subpackages()
                             if newsection == "files" then
                                 subparam = param:match("%%{python_files%s+(.*)}")
                             else
-                                subparam = param:match("^%-n%s+%%{python_flavor}%-(.*)$")
+                                subparam = param:match("^%-n%s+python%-(.*)$")
                             end
                             if subparam then
                                 local submodname, subsubparam = rpm.expand(subparam):match("^(%S+)%s*(.*)$")


### PR DESCRIPTION
We have to change the `%python_subpackage_only` logic. The use of `%package -n %{python_flavor}-foo` conflicts with the fact that we need to rewrite the tag values of the subpackage for the default provider too.