### PR TITLE
Fix python_provides for default provider

### DIFF
--- a/functions.lua
+++ b/functions.lua
@@ -34,7 +34,7 @@ SHORT_FLAVORS = {
 function replace_macros(str, targetflavor)
     local LONG_MACROS = { "sitelib", "sitearch",
         "alternative", "install_alternative", "uninstall_alternative",
-        "version", "version_nodots", "bin_suffix", "prefix"}
+        "version", "version_nodots", "bin_suffix", "prefix", "provides"}
     local SHORT_MACROS = { "ver" }
     for _, srcflavor in ipairs({flavor, "python"}) do
         str = str:gsub("%%__" .. srcflavor, "%%__" .. targetflavor)

--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -38,6 +38,7 @@
 
 %python_prefix                  %{_rec_macro_helper}%{lua:expand_macro("prefix")}
 %python_bin_suffix              %{_rec_macro_helper}%{lua:expand_macro("bin_suffix")}
+%python_provides                %{_rec_macro_helper}%{lua:expand_macro("provides")}
 
 %python_sysconfig_path()        %{_rec_macro_helper}%{lua:call_sysconfig("path", "%{__%python_flavor}")}
 %python_sysconfig_var()         %{_rec_macro_helper}%{lua:call_sysconfig("var", "%{__%python_flavor}")}


### PR DESCRIPTION
This is for the correct handling of f2py3 in python-numpy (https://github.com/openSUSE/python-rpm-macros/issues/66#issuecomment-734271479)