### PR TITLE
fix print_provided_flavor

### DIFF
--- a/macros.lua
+++ b/macros.lua
@@ -386,7 +386,7 @@ function python_subpackages()
                         section_function = ignore_line
                     elseif newsection == "package" then
                         print(section_headline("package", current_flavor, param))
-                        print_provided_flavor(modname .. "-" .. param)
+                        print_provided_flavor(modname)
                         section_function = process_package_line
                     elseif newsection == "files" and current_flavor == flavor then
                         section_function = ignore_line


### PR DESCRIPTION
Fixes unresolvable protobuf in Staging:N (see #66), because javapackages-tools:extras currently provides python3-javapackages- with the trailing `-`.

The wrong  `.. "-" .. param` concatenation was already present with the call of old `print_obsoletes()`. I am surprised that it didn't surface in the past 4 years.