### PR TITLE
remove python2 not found error

### DIFF
--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -3,8 +3,8 @@
 
 ##### common functionality #####
 
-%_python_sysconfig_path() %(%1 -c "import sysconfig as s; print(s.get_paths().get('%2'))")
-%_python_sysconfig_var()  %(%1 -c "import sysconfig as s; print(s.get_config_var('%2'))")
+%_python_sysconfig_path() %([ -x %1 ] && %1 -c "import sysconfig as s; print(s.get_paths().get('%2'))" || echo "!!%1 not installed!!")
+%_python_sysconfig_var()  %([ -x %1 ] && %1 -c "import sysconfig as s; print(s.get_config_var('%2'))"  || echo "!!%1 not installed!!")
 
 %_rec_macro_helper %{lua:
     rpm.define("_rec_macro_helper %{nil}")


### PR DESCRIPTION
This removes the annoying `sh: /usr/bin/python2: No such file or directory` error at the beginning of each rpmbuild on Tumbleweed. 

Also creates a better diagnostic for cases, when a  `%pythonXX_foo` macro that uses `%_python_sysconfig_path()`, is executed, but the interpreter of the flavor is not installed. (e.g. see current failures in build targets where the latest python-rpm-macros with more flavors is imported but the new definition of pythons in the prjconf is still missing.)