### PR TITLE
[WIP] support variable %python in %python_module

### DIFF
--- a/buildset.in
+++ b/buildset.in
@@ -1,9 +1,9 @@
 
 # This method for generating python_modules gets too deep to expand at about 5 python flavors.
 # It is replaced by a Lua macro in macros.lua
-# However, OBS has a much higher expansion depth, so this works fine.
-%python_module_iter(a:) %{-a*}-%{args} %{expand:%%{?!python_module_iter_%1:%%{python_module_iter -a %*}}}
+# However, OBS has a much higher expansion depth, so this works fine for the server side resolver.
+# Put this into your prjconf
+%python_module_iter(a:) %{expand:%%define python %{-a*}} ( %python-%args ) %{expand:%%{?!python_module_iter_%1:%%{python_module_iter -a%*}}%%{?python_module_iter_%1:%%define python %%%%python}}
 %python_module_iter_STOP stop
 %python_module() %{expand:%%define args %{**}} %{expand:%%{python_module_iter -a %{pythons} STOP}}
-
 %add_python() %{expand:%%define pythons %pythons %1}

--- a/macros.lua
+++ b/macros.lua
@@ -519,13 +519,8 @@ end
 
 function python_module()
     rpm.expand("%_python_macro_init")
-    local params = rpm.expand("%**")
     for _, python in ipairs(pythons) do
-        if python == "python2" then
-            print(rpm.expand("%python2_prefix") .. "-" .. params)
-        else
-            print(python .. "-" .. params)
-        end
-        print(" ")
+        rpm.define("python %" .. python .. "_prefix")
+        print(rpm.expand("%python-%**") .. " ")
     end
 end


### PR DESCRIPTION
This allows us to [put boolean rpm dependencies](https://rpm.org/user_doc/boolean_dependencies.html) into %{python_module } referring to the expanded python flavor.

[Example package](https://build.opensuse.org/package/show/home:bnavigator:branches:devel:languages:python:Factory/python-testpac-rpm)

```spec
BuildRequires:  %{python_module ABCD36 and %python-base <= 3.6}
BuildRequires:  %{python_module ABCD38 and %python-base >= 3.8}
BuildRequires:  %{python_module XYZ and %python-XYZ2 and NOPY}
```


```
> osc build
...
buildinfo is broken... it says:
unresolvable: nothing provides (python36-ABCD36 and python36-base <= 3.6)
      nothing provides (python38-ABCD36 and python38-base <= 3.6)
      nothing provides (python36-ABCD38 and python36-base >= 3.8)
      nothing provides (python38-ABCD38 and python38-base >= 3.8)
      nothing provides (python36-XYZ and python36-XYZ2 and NOPY)
      nothing provides (python38-XYZ and python38-XYZ2 and NOPY)
```

(In a real world package, replace the `and %python-base <= 3.6` with ` if %python-base <= 3.6`)