### PR TITLE
Add %python pseudo-macro for %python_modules -- server and rpm version

### DIFF
--- a/buildset.in
+++ b/buildset.in
@@ -1,9 +1,10 @@
-
-# This method for generating python_modules gets too deep to expand at about 5 python flavors.
-# It is replaced by a Lua macro in macros.lua
-# However, OBS has a much higher expansion depth, so this works fine.
-%python_module_iter(a:) %{-a*}-%{args} %{expand:%%{?!python_module_iter_%1:%%{python_module_iter -a %*}}}
-%python_module_iter_STOP stop
-%python_module() %{expand:%%define args %{**}} %{expand:%%{python_module_iter -a %{pythons} STOP}}
+# prjconf definitions for python-rpm-macros
+# This method for generating python_modules gets too deep to expand for rpm at about 5 python flavors.
+# Hence, python_module_iter is replaced by python_module_lua in macros.lua.
+# However, OBS cannot expand lua, but has a much higher expansion depth, so this works fine for the server side resolver.
+%python_module_iter(a:) %{expand:%%define python %{-a*}} ( %python-%args ) %{expand:%%{?!python_module_iter_%1:%%{python_module_iter -a%*}}%%{?python_module_iter_%1}}
+# pseudo-undefine for obs: reset for the next expansion within the next call of python_module
+%python_module_iter_STOP %global python %%%%python
+%python_module() %{?!python_module_lua:%{expand:%%define args %{**}} %{expand:%%{python_module_iter -a %{pythons} STOP}}}%{?python_module_lua:%python_module_lua %{**}}
 
 %add_python() %{expand:%%define pythons %pythons %1}

--- a/macros.lua
+++ b/macros.lua
@@ -517,15 +517,12 @@ function python_clone(a)
     end
 end
 
-function python_module()
+-- called by %python_module, see buildset.in
+function python_module_lua()
     rpm.expand("%_python_macro_init")
     local params = rpm.expand("%**")
     for _, python in ipairs(pythons) do
-        if python == "python2" then
-            print(rpm.expand("%python2_prefix") .. "-" .. params)
-        else
-            print(python .. "-" .. params)
-        end
-        print(" ")
+        local python_prefix = rpm.expand("%" .. python .. "_prefix")
+        print("(" .. python_prefix .. "-" .. string.gsub(params, "%%python", python_prefix) .. ") ")
     end
 end


### PR DESCRIPTION
New version of #88 that works both on server side and with rpm itself.

Fixes #89.

See https://build.opensuse.org/project/show/home:bnavigator:branches:devel:languages:python:Factory