### PR TITLE
Workaround for undetected ABI and platform tags

### DIFF
--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -143,16 +143,21 @@
 ##### PEP-518 macros #####
 %pyproject_wheel(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua:\
     local args = rpm.expand("%**"); \
-    local intro = "%{python_expand $python -mpip wheel --no-deps %{?py_setup_args:--build-option %{py_setup_args}}"; \
-    intro = intro .. " --disable-pip-version-check --use-pep517 --no-build-isolation --progress-bar off --verbose . "; \
-    print(rpm.expand(intro .. args .. "}")) \
+    local pyexpandstart = "%{python_expand "; \
+    local buildwheel = "$python -mpip wheel --no-deps %{?py_setup_args:--build-option %{py_setup_args}}"; \
+    buildwheel = buildwheel .. " --disable-pip-version-check --use-pep517 --no-build-isolation --progress-bar off --verbose . -w build/ "; \
+    -- remove abi and platform tags from filename in case the package does define them incorrectly (see PEP427 for valid filenames) \
+    -- single percent for shell out of four percent by rpm.expand \
+    local renamewheel = "fn=(build/*.whl); mv $fn ${fn%%%%-*-*.whl}-none-any.whl"; \
+    local pyexpandend = "}"; \
+    print(rpm.expand(pyexpandstart .. buildwheel .. args .. "; " .. renamewheel .. pyexpandend)) \
 }
 
 # No such option: --strip-file-prefix %%{buildroot} 
 %pyproject_install(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua:\
     local args = rpm.expand("%**"); \
     local broot = rpm.expand("--root %buildroot"); \
-    local intro = "%{python_expand $python -mpip install " .. broot .. " --disable-pip-version-check --no-compile --no-deps  --progress-bar off *.whl "; \
+    local intro = "%{python_expand $python -mpip install " .. broot .. " --disable-pip-version-check --no-compile --no-deps  --progress-bar off build/*-none-any.whl"; \
     print(rpm.expand(intro .. args .. "}")) \
     print(rpm.expand("%python_compileall"))
 }


### PR DESCRIPTION
closes #93

https://www.python.org/dev/peps/pep-0427/
https://www.python.org/dev/peps/pep-0425/

Successful build in https://build.opensuse.org/package/show/home:bnavigator:python-rpm-macros/python-pendulum