### PR TITLE
Sync %pythons to Factory prjconf definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ other files in non-flavor-specific locations. By default, set to `python3`.
 
 * __`%pythons`__ - the build set. See above for details.
 
-* __`%have_<flavor`__. Defined as 1 if the flavor is present in the build environment.
+* __`%have_<flavor>`__. Defined as 1 if the flavor is present in the build environment.
   Undefined otherwise.
 
   _Note:_ "present in build environment" does not mean "part of build set". Under some

--- a/buildset.in
+++ b/buildset.in
@@ -1,4 +1,14 @@
-# prjconf definitions for python-rpm-macros
+# buildset.in: prjconf definitions for python-rpm-macros.
+#
+# This is usually overridden by the distribution's prjconf, landing in ~/.rpmmacros.
+# This file provides the default definition from Factory (Tumbleweed) for pure rpmbuild packaging.
+
+# order of %pythons is important: The last flavor overrides any operation on conflicting files and definitions during expansions,
+# making it the "default" in many cases --> keep the primary python3 provider at the end.
+%pythons %{?!skip_python3:%{?!skip_python36:python36} %{?!skip_python38:python38}}
+%skip_python2 1
+%_without_python2 1
+
 # This method for generating python_modules gets too deep to expand for rpm at about 5 python flavors.
 # Hence, python_module_iter is replaced by python_module_lua in macros.lua.
 # However, OBS cannot expand lua, but has a much higher expansion depth, so this works fine for the server side resolver.

--- a/compile-macros.sh
+++ b/compile-macros.sh
@@ -1,11 +1,8 @@
 #!/bin/bash
 
-FLAVORS="python2 python3 python36 python38 pypy3"
-
-# order of BUILDSET is important, it is copied to order of %pythons,
-# and that determines the last installed binary
-BUILDSET="python2 python3 python36 python38"
-
+# The set of flavors for which we produce macros. Not identical to
+# the buildset predefined for specific distributions (see below)
+FLAVORS="python2 python3 python36 python38 python39 pypy3"
 
 ### flavor-specific: generate from flavor.in
 for flavor in $FLAVORS; do
@@ -17,13 +14,9 @@ for flavor in $FLAVORS; do
 done
 
 
-### buildset: generate %pythons, %skip_python? and %python_modules
-pythons=""
-for flavor in $BUILDSET; do
-    pythons="${pythons} %{?!skip_$flavor:$flavor}"
-done
-echo "%pythons $pythons" > macros/040-buildset
-cat buildset.in >> macros/040-buildset
+### buildset: %pythons, %python_module and %add_python, usually overidden
+# by the distribution's prjconf
+cat buildset.in > macros/040-buildset
 
 
 ### Lua: generate automagic from macros.in and macros.lua

--- a/macros-default-pythons
+++ b/macros-default-pythons
@@ -1,5 +1,6 @@
 # this file should be excluded for new distributions,
 # where %have_$flavor is determined by installed python packages
+# (see python-rpm-macros.spec)
 
 %have_python2 1
 %have_python3 1


### PR DESCRIPTION
Per @DimStar77's request: A local rpmbuild should be close to what happens on the build service. Provide the default buildset in python-rpm-macros like it is defined by the [Factory prjconf](https://build.opensuse.org/projects/openSUSE:Factory/prjconf).

This PR also enables the creation of macros for a `python39`, but `python39`  is not included into the buildset yet.