### PR TITLE
Only add parentheses in %python_module (_lua) when boolean operators are used.

### DIFF
--- a/macros.lua
+++ b/macros.lua
@@ -521,8 +521,19 @@ end
 function python_module_lua()
     rpm.expand("%_python_macro_init")
     local params = rpm.expand("%**")
+    -- The Provides: tag does not support boolean dependencies, so only add parens if needed
+    local lpar = ""
+    local rpar = ""
+    local OPERATORS = lookup_table { 'and', 'or', 'if', 'with', 'without', 'unless'}
+    for p in string.gmatch(params, "%S+") do
+        if OPERATORS[p] then
+            lpar = "("
+            rpar = ")"
+            break
+        end
+    end
     for _, python in ipairs(pythons) do
         local python_prefix = rpm.expand("%" .. python .. "_prefix")
-        print("(" .. python_prefix .. "-" .. string.gsub(params, "%%python", python_prefix) .. ") ")
+        print(lpar .. python_prefix .. "-" .. string.gsub(params, "%%python", python_prefix) .. rpar .. " ")
     end
 end


### PR DESCRIPTION
%python_module is sometimes used for `Provides:`  tags. We cannot use boolean rpm dependencies -- including parantheses -- there:

```
[ 20s] error: line 60: No rich dependencies allowed for this type: Provides: (python36-six-doc = 1.15.0) (python38-six-doc = 1.15.0)
```

With the fix:
```
> rpm -q --provides /var/tmp/build-root/openSUSE_Tumbleweed-x86_64/home/abuild/rpmbuild/RPMS/noarch/python-six-doc-1.15.0-0.noarch.rpm

python-six-doc = 1.15.0-0
python36-six-doc = 1.15.0
python38-six-doc = 1.15.0
```

```
[ben@skylab:~/src/osc/home:bnavigator:python-rpm-macros/python-six]% osc shell 
abuild@skylab:~> rpm --eval '%{python_module one}'
 python36-one python38-one
abuild@skylab:~> rpm --eval '%{python_module one and two}'
 (python36-one and two) (python38-one and two)
abuild@skylab:~> rpm --eval '%{python_module one if two}'
 (python36-one if two) (python38-one if two)
abuild@skylab:~> rpm --eval '%{python_module one if two > 1}'
 (python36-one if two > 1) (python38-one if two > 1)
abuild@skylab:~> rpm --eval '%{python_module oneandtwo}'
 python36-oneandtwo python38-oneandtwo
abuild@skylab:~> rpm --eval '%{python_module one if %python-base < 3.8}'
 (python36-one if python36-base < 3.8) (python38-one if python38-base < 3.8)

```

The OBS version of  `%python_module` stays the same and always prints parentheses. It only evaluates ` BuildRequires` for the packages to install into the environment.