### PR TITLE
Expand python_subpackage_only not earlier than in python_subpackages

### DIFF
--- a/macros.lua
+++ b/macros.lua
@@ -54,17 +54,6 @@ function _python_scan_spec()
 
     -- find the spec file
     specpath = rpm.expand("%_specfile")
-
-    -- search possible locations - shouldn't be necessary anymore
---    local locations = { rpm.expand("%_sourcedir"), rpm.expand("%_specdir"), posix.getcwd(), posix.getcwd() .. "/" .. name }
---    for _,loc in ipairs(locations) do
---        local filename = loc .. "/" .. name .. ".spec"
---        if posix.stat(filename, "mode") ~= nil then
---            io.stderr:write("could not find spec as " .. filename .. "\n")
---            specpath = filename
---            break
---        end
---    end
 end
 
 function python_subpackages()

--- a/macros.lua
+++ b/macros.lua
@@ -52,12 +52,6 @@ function _python_scan_spec()
         flavor = spec_name_prefix
     end
 
-    subpackage_only = rpm.expand("0%{?python_subpackage_only}") ~= "0"
-    if subpackage_only then
-        is_called_python = false
-        modname = ""
-    end
-
     -- find the spec file
     specpath = rpm.expand("%_specfile")
 
@@ -79,6 +73,12 @@ function python_subpackages()
 
     local current_flavor  = flavor
     local original_flavor = rpm.expand("%python_flavor")
+
+    subpackage_only = rpm.expand("%{python_subpackage_only}") == "1"
+    if subpackage_only then
+        is_called_python = false
+        modname = ""
+    end
 
     -- line processing functions
     local function print_altered(line)

--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -3,8 +3,8 @@
 
 ##### common functionality #####
 
-%_python_sysconfig_path() %([ -x %1 ] && %1 -c "import sysconfig as s; print(s.get_paths().get('%2'))" || echo "!!%1 not installed!!")
-%_python_sysconfig_var()  %([ -x %1 ] && %1 -c "import sysconfig as s; print(s.get_config_var('%2'))"  || echo "!!%1 not installed!!")
+%_python_sysconfig_path() %([ -x %1 ] && %1 -c "import sysconfig as s; print(s.get_paths().get('%2'))" || echo "!!_%1_not_installed_!!")
+%_python_sysconfig_var()  %([ -x %1 ] && %1 -c "import sysconfig as s; print(s.get_config_var('%2'))"  || echo "!!_%1_not_installed_!!")
 
 %_rec_macro_helper %{lua:
     rpm.define("_rec_macro_helper %{nil}")


### PR DESCRIPTION
`%python_subpackage_only` was expanded too early through `_python_macro_init() -> _python_scan_spec()` because now `%python_module_lua()` also calls it. The prjconf override did not. Hence the necessary move to `%python_subpackages`.

Note: The python_subpackages macro seems to run into some rpm/lua line limit for macros/functions. Adding any more lines, including comments, creates an unterminated body error.

Extra: let `_python_sysconfig_*`  return a string without whitespace, so that we don't break opencv3, which uses `%python2_sitelib` as CMake parameter despite not having python2 installed.