### PR TITLE
don't define skip_python2 by default

### DIFF
--- a/buildset.in
+++ b/buildset.in
@@ -6,8 +6,12 @@
 # order of %pythons is important: The last flavor overrides any operation on conflicting files and definitions during expansions,
 # making it the "default" in many cases --> keep the primary python3 provider at the end.
 %pythons %{?!skip_python3:%{?!skip_python36:python36} %{?!skip_python38:python38}}
-%skip_python2 1
-%_without_python2 1
+%add_python() %{expand:%%define pythons %1 %pythons}
+
+# Factory also defines these, but for cases where they are not defined at all (SLE, Leap) we cannot define them here, because they
+# would not be overridden.
+#%%skip_python2 1
+#%%_without_python2 1
 
 # This method for generating python_modules gets too deep to expand for rpm at about 5 python flavors.
 # Hence, python_module_iter is replaced by python_module_lua in macros.lua.
@@ -17,4 +21,3 @@
 %python_module_iter_STOP %global python %%%%python
 %python_module() %{?!python_module_lua:%{expand:%%define args %{**}} %{expand:%%{python_module_iter -a %{pythons} STOP}}}%{?python_module_lua:%python_module_lua %{**}}
 
-%add_python() %{expand:%%define pythons %pythons %1}


### PR DESCRIPTION
The Leap backports do not like the default skip introduced in #97