### PR TITLE
Read .rpmmacros (= prjconf Macro: definitions) for default buildset

### DIFF
--- a/compile-macros.sh
+++ b/compile-macros.sh
@@ -14,10 +14,22 @@ for flavor in $FLAVORS; do
 done
 
 
-### buildset: %pythons, %python_module and %add_python, usually overidden
-# by the distribution's prjconf
-cat buildset.in > macros/040-buildset
-
+### buildset: %pythons, %python_module and %add_python, coming from
+# the current build target's prjconf
+echo "Setting buildset:"
+echo "## Python Buildset Begin" | tee macros/040-builset-start
+# First try to find the block from Factory
+sed -n '/## PYTHON MACROS BEGIN/,/## PYTHON MACROS END/ p' ~/.rpmmacros | tee macros/041-buildset
+# If that fails, find the old definitions (SUSE:SLE-15-SP?:GA, openSUSE:Leap:15.?)
+if [ ! -s macros/041-buildset ]; then
+    sed -n '/%pythons/,/%add_python/ p' ~/.rpmmacros | tee macros/041-buildset
+fi
+# If we still have nothing (different distro, custom prjconf, building
+# python-rpm-macros outside of obs), use the default file
+if [ ! -s macros/041-buildset ]; then
+    tee macros/041-buildset < default-prjconf
+fi
+echo "## Python Buildset End" | tee macros/042-builset-end
 
 ### Lua: generate automagic from macros.in and macros.lua
 (

--- a/default-prjconf
+++ b/default-prjconf
@@ -1,17 +1,16 @@
-# buildset.in: prjconf definitions for python-rpm-macros.
+# default-prjconf: buildset definitions for python-rpm-macros.
 #
 # This is usually overridden by the distribution's prjconf, landing in ~/.rpmmacros.
 # This file provides the default definition from Factory (Tumbleweed) for pure rpmbuild packaging.
 
+# Macros:
+## PYTHON MACROS BEGIN
 # order of %pythons is important: The last flavor overrides any operation on conflicting files and definitions during expansions,
 # making it the "default" in many cases --> keep the primary python3 provider at the end.
 %pythons %{?!skip_python3:%{?!skip_python36:python36} %{?!skip_python38:python38}}
 %add_python() %{expand:%%define pythons %1 %pythons}
 
-# Factory also defines these, but for cases where they are not defined at all (SLE, Leap) we cannot define them here, because they
-# would not be overridden.
-#%%skip_python2 1
-#%%_without_python2 1
+%_without_python2 1
 
 # This method for generating python_modules gets too deep to expand for rpm at about 5 python flavors.
 # Hence, python_module_iter is replaced by python_module_lua in macros.lua.
@@ -20,4 +19,5 @@
 # pseudo-undefine for obs: reset for the next expansion within the next call of python_module
 %python_module_iter_STOP %global python %%%%python
 %python_module() %{?!python_module_lua:%{expand:%%define args %{**}} %{expand:%%{python_module_iter -a %{pythons} STOP}}}%{?python_module_lua:%python_module_lua %{**}}
-
+## PYTHON MACROS END
+# :Macros


### PR DESCRIPTION
* This makes sure building a package directly with rpmbuild uses the same
  definitions for the distribution of the host as with the build target of
  the build service

See build logs of
https://build.opensuse.org/package/show/home:bnavigator:python-rpm-macros/python-rpm-macros

SLE12 backports and the sort still need to be fixed by appropriate prjconf definitions.