### PR TITLE
Fixes for PEP517/PEP518 macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,11 +218,14 @@ is the basename of the flavor executable. Make sure it is in `$PATH`.
 * __`%python_install`__ expands to distutils/setuptools install instructions for all flavors.
 
 * __`%pyproject_wheel`__ expands to 
-[PEP517](https://www.python.org/dev/peps/pep-0517)/[PEP518](https://www.python.org/dev/peps/pep-0518/)
-build instructions for all flavors and creates wheels. This is useful if the package has a 
-``pyproject.toml`` file but no ``setup.py``
+  [PEP517](https://www.python.org/dev/peps/pep-0517)/[PEP518](https://www.python.org/dev/peps/pep-0518/)
+  build instructions for all flavors, creates wheels and places them into the flavor's `build/` directories.
+  This is useful if the package has a ``pyproject.toml`` file but no ``setup.py``.
 
-* __`%pyproject_install`__ expands to install instructions for all flavors to install the created wheels.
+* __`%pyproject_install [wheelfile]`__ expands to install instructions for all flavors to install the created wheels.
+  You can also use this without `%pyproject_wheel`, if you place a pre-existing wheel into the current working dir
+  (deprecated), the `build/` directory of the current flavor (what `%pyproject_wheel` does), or specify
+  the path to the wheel file explicitly as argument to the macro (preferred), e.g `%pyproject_install %{SOURCE0}`.
 
 * __`%python_compileall`__ precompiles all python source files in `%{python_sitelib}` and `%{python_sitearch}`
 for all flavors. Generally Python 2 creates the cached byte-code `.pyc` files directly in the script directories, while

--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -148,7 +148,7 @@
     buildwheel = buildwheel .. " --disable-pip-version-check --use-pep517 --no-build-isolation --progress-bar off --verbose . -w build/ "; \
     -- remove abi and platform tags from filename in case the package does define them incorrectly (see PEP427 for valid filenames) \
     -- single percent for shell out of four percent by rpm.expand \
-    local renamewheel = "fn=(build/*.whl); mv -n $fn ${fn%%%%-*-*.whl}-none-any.whl"; \
+    local renamewheel = "fn=(build/*.whl); fn2=${fn%%%%-*-*.whl}-none-any.whl"; if [ ! $fn -ef $fn2 ]; then mv $fn $fn2; fi" \
     local pyexpandend = "}"; \
     print(rpm.expand(pyexpandstart .. buildwheel .. args .. "; " .. renamewheel .. pyexpandend)) \
 }

--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -157,9 +157,16 @@
 %pyproject_install(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua:\
     local args = rpm.expand("%**"); \
     local broot = rpm.expand("--root %buildroot"); \
-    local intro = "%{python_expand $python -mpip install " .. broot .. " --disable-pip-version-check --no-compile --no-deps  --progress-bar off build/*.whl"; \
-    print(rpm.expand(intro .. args .. "}")) \
-    print(rpm.expand("%python_compileall"))
+    local pyexpandstart = "%{python_expand # \\n"; \
+    local findwheel = "wheelinargs=0 \\n"; \
+    if args ~= "" then \
+      findwheel = findwheel .. "for a in " .. args .. "; do if [ -f $a -a ${a: -3} = 'whl' ]; then wheelinargs=1; break; fi; done \\n"; \
+    end \
+    findwheel = findwheel .. "if [ $wheelinargs -eq 0 ]; then if [ -f build/*.whl ]; then wheelname=build/*.whl; else wheelname=*.whl; fi; fi \\n"; \
+    local installwheel = "$python -mpip install " .. broot .. " --disable-pip-version-check --no-compile --no-deps  --progress-bar off " .. args .. " $wheelname"; \
+    local pyexpandend = "}"; \
+    print(rpm.expand(pyexpandstart .. findwheel .. installwheel .. pyexpandend)) \
+    print(rpm.expand("%python_compileall")) \
 }
 
 ##### Precompile scripts macro #####


### PR DESCRIPTION
* Too many packages are using `%pyproject_install` without `%pyproject_wheel` and are not happy with the move of the wheel file to `build/` (#94)
* SLE12 backports did not like the "mv -n"
* Expand documentation about PEP517/PEP518 macros