### PR TITLE
Update default-prjconf

### DIFF
--- a/default-prjconf
+++ b/default-prjconf
@@ -7,7 +7,7 @@
 ## PYTHON MACROS BEGIN
 # order of %pythons is important: The last flavor overrides any operation on conflicting files and definitions during expansions,
 # making it the "default" in many cases --> keep the primary python3 provider at the end.
-%pythons %{?!skip_python3:%{?!skip_python36:python36} %{?!skip_python38:python38}}
+%pythons %{?!skip_python3:%{?!skip_python36:python36} %{?!skip_python39:python39} %{?!skip_python38:python38}}
 %add_python() %{expand:%%define pythons %1 %pythons}
 
 %_without_python2 1


### PR DESCRIPTION
python39 was just enabled in openSUSE:Factory. Reflect this in the default-prjconf.