### PR TITLE
increase default python3 update-alternative prio by 1000

### DIFF
--- a/functions.lua
+++ b/functions.lua
@@ -122,6 +122,12 @@ function python_install_alternative(flavor)
     local prio      = rpm.expand("%" .. flavor .. "_version_nodots")
     local binsuffix = rpm.expand("%" .. flavor .. "_bin_suffix")
 
+    -- increase priority for primary python3 flavor
+    local provides = rpm.expand("%" .. flavor .. "_provides") .. " "
+    if provides:match("python3%s") then
+        prio = prio + 1000
+    end
+
     local params = {}
     for p in string.gmatch(rpm.expand("%*"), "%S+") do
         table.insert(params, p)


### PR DESCRIPTION
Closes #109 

```
abuild@skylab:~> rpm -E '%python36_install_alternative x'
 
update-alternatives --quiet --install /usr/bin/x x /usr/bin/x-3.6 36
abuild@skylab:~> rpm -E '%python38_install_alternative x'
 
update-alternatives --quiet --install /usr/bin/x x /usr/bin/x-3.8 1038
abuild@skylab:~> rpm -E '%python39_install_alternative x'
 
update-alternatives --quiet --install /usr/bin/x x /usr/bin/x-3.9 39
abuild@skylab:~> rpm -E '%python3_install_alternative x'
 
update-alternatives --quiet --install /usr/bin/x x /usr/bin/x-3.8 38
```
