### PR TITLE
fix boolean split gh#openSUSE/python-rpm-macros#111

### DIFF
--- a/macros.lua
+++ b/macros.lua
@@ -127,15 +127,15 @@ function python_subpackages()
                 end
                 return package
             end
-            local before, inner, remainder
-            inner, remainder = value:match("^packageand(%b())%s*(.*)$")
+            local before, inner, space, remainder
+            inner, space, remainder = value:match("^packageand(%b())(%s*)(.*)$")
             if inner then
-                return "packageand(" .. inner:sub(2,-2):gsub("[^:]+", rename_package) .. ") " .. replace_prefix_r(tostring(remainder))
+                return "packageand(" .. inner:sub(2,-2):gsub("[^:]+", rename_package) .. ")" .. space .. replace_prefix_r(tostring(remainder))
             end
-            before, inner, remainder = value:match("^([^()]*)(%b())%s*(.*)$")
+            before, inner, space, remainder = value:match("^([^()]*)(%b())(%s*)(.*)$")
             if inner then
-                return replace_prefix_r(tostring(before)) .. " (".. replace_prefix_r(inner:sub(2, -2)) ..  ") " .. replace_prefix_r(tostring(remainder))
-            end            
+                return replace_prefix_r(tostring(before)) .. "(".. replace_prefix_r(inner:sub(2, -2)) ..  ")" .. space .. replace_prefix_r(tostring(remainder))
+            end
             return value:gsub("%S+", rename_package)
         end
 


### PR DESCRIPTION
Fixes #111:

```
[ben@skylab:…ac-rpm-runtime]% grep '^Requires:' python-testpac-rpm-runtime.spec                                                                                                                                [0]
Requires:       (python-AifB if python-B)
Requires:       (python-A36 if python36-base)
Requires:       (python-A38 if (python-base >= 3.8 with python38-base))
Requires:       (python-C and python-D and NOPY)
Requires:       (python-E and (python-F and NOPY2))
Requires:       packageand(python-A:python-B)
Requires:       packageand(python-C:D)
Requires:       packageand(E:python-F)
Requires:       python-AXY some-extra-package-on-same-line python-same-line
Requires:       tex(abcd)
Requires:       tex(abcd.xxy)
Requires:       pkgconfig(abcd) another-package-after-parens
Requires:       python-Plain
Requires:       python36-Plain36
Requires:       python38-Plain38
Requires:       python3-Plain3
[ben@skylab:…ac-rpm-runtime]% rpm -q --requires /var/tmp/build-root/dlp_Tumbleweed-x86_64/home/abuild/rpmbuild/RPMS/noarch/python36-testpac-rpm-runtime-0.2-0.noarch.rpm                                       [0]

(python36-A36 if python36-base)
(python36-A38 if (python36-base >= 3.8 with python36-base))
(python36-AifB if python36-B)
(python36-C and python36-D and NOPY)
(python36-E and (python36-F and NOPY2))
another-package-after-parens
packageand(E:python36-F)
packageand(python36-A:python36-B)
packageand(python36-C:D)
pkgconfig(abcd)
python3-Plain3
python36-AXY
python36-Plain
python36-Plain36
python36-Plain38
python36-base = 3.6.13
python36-same-line
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(PayloadIsZstd) <= 5.4.18-1
rpmlib(RichDependencies) <= 4.12.0-1
some-extra-package-on-same-line
tex(abcd)
tex(abcd.xxy)
[ben@skylab:…ac-rpm-runtime]% rpm -q --requires /var/tmp/build-root/dlp_Tumbleweed-x86_64/home/abuild/rpmbuild/RPMS/noarch/python38-testpac-rpm-runtime-0.2-0.noarch.rpm                                       [0]

(python38-A36 if python36-base)
(python38-A38 if (python38-base >= 3.8 with python38-base))
(python38-AifB if python38-B)
(python38-C and python38-D and NOPY)
(python38-E and (python38-F and NOPY2))
another-package-after-parens
packageand(E:python38-F)
packageand(python38-A:python38-B)
packageand(python38-C:D)
pkgconfig(abcd)
python3-Plain3
python36-Plain36
python38-AXY
python38-Plain
python38-Plain38
python38-base = 3.8.10
python38-same-line
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(PayloadIsZstd) <= 5.4.18-1
rpmlib(RichDependencies) <= 4.12.0-1
some-extra-package-on-same-line
tex(abcd)
tex(abcd.xxy)
[ben@skylab:…ac-rpm-runtime]%                                                                                                                                                                                  [0]



[ben@skylab:…/python-Sphinx]% rpm -q --requires /var/tmp/build-root/dlp_Tumbleweed-x86_64/home/abuild/rpmbuild/RPMS/noarch/python38-Sphinx-latex-4.0.2-0.noarch.rpm                                            [0]
python38-Sphinx = 4.0.2
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(PayloadIsZstd) <= 5.4.18-1
tex(8r.enc)
tex(alltt.sty)
...
```