### PR TITLE
Definitions of %python_site{lib,arch}_module macros.

### DIFF
--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -46,6 +46,17 @@
 
 %py_ver  %python_version
 
+%python_sitelib_module() %{lua:\
+        name = rpm.expand("%{?1:%{1}}");\
+        print("%{python_sitelib}/" .. name .."\n" .. "%{python_sitelib}/" .. name .. "-%{version}-py*.egg-info");\
+}
+
+%python_sitearch_module() %{lua:\
+        name = rpm.expand("%{?1:%{1}}");\
+        print("%{python_sitearch}/" .. name .."\n" .. "%{python_sitearch}/" .. name .. "-%{version}-py*.egg-info");\
+}
+
+
 ##### Python dependency generator macros #####
 
 # === Macros for Build/Requires tags using Python dist tags ===


### PR DESCRIPTION
We should really break the bad habit of `%{python_sitelib}/*`

Use would be (in `%files`) something like:
```rpm
%{python_sitelib_module foo}
```
for the package `python-foo`.

@bnavigator  @s-t-e-v-e-n-k , what do you think?