### PR TITLE
no newline after python_install_alternative

### DIFF
--- a/flavor.in
+++ b/flavor.in
@@ -62,8 +62,7 @@ end \
 
 %#FLAVOR#_install_alternative() \
 %{_python_macro_init} \
-%{lua:python_install_alternative("#FLAVOR#")} \
-%{nil}
+%{lua:python_install_alternative("#FLAVOR#")}
 
 %#FLAVOR#_uninstall_alternative() \
 %if ! %{with libalternatives} \


### PR DESCRIPTION
#117 introduced a newline after `%python_install_alternative`. This is wrong and produces errors like this one in python-qt5:

```spec
%post devel
%{python_install_alternative pyuic5 pylupdate5 pyrcc5} \
   --slave %{_datadir}/sip/PyQt5 pyqt5-sip %{_datadir}/pyqt5-sip-%{python_bin_suffix}
```

```
# rpm -q --scripts python38-qt5-devel-5.15.5-0.x86_64.rpm
postinstall scriptlet (using /bin/sh):

 
update-alternatives --quiet --install /usr/bin/pyuic5 pyuic5 /usr/bin/pyuic5-3.8 1038 \
   --slave /usr/bin/pylupdate5 pylupdate5 /usr/bin/pylupdate5-3.8 \
   --slave /usr/bin/pyrcc5 pyrcc5 /usr/bin/pyrcc5-3.8 
 \
   --slave /usr/share/sip/PyQt5 pyqt5-sip /usr/share/pyqt5-sip-3.8
```

```
[ 3271s] ... testing for pre/postinstall scripts that are not idempotent
[ 3272s] /.build_patchrpmcheck_scr: line 7: --slave: command not found
```

This PR fixes it. The other `%python_*_alternative` macros produce commands with `if` blocks ending in `fi`, so the extra newline is warranted.