### PR TITLE
Add %python_flavored_alternatives and use for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ to override this behavior.
 Note that if you created a group by specifying multiple arguments to `install_alternative`, only
 the first one applies for `uninstall_alternative`.
 
-  Each of these has a flavor-specific spelling: `%python2_alternative` etc.
+Each of these has a flavor-specific spelling: `%python2_alternative` etc.
 
 
 #### Libalternatives-related:
@@ -331,6 +331,23 @@ spec file:
   %python_libalternatives_reset_alternative <name>
   ```
   The argument *\<name\>* is the same used for calling *%python_uninstall_alternative*.
+
+#### Building and testing with flavored alternatives
+
+* __`%python_flavored_alternatives`__: If a build tool or a test
+  suite calls commands, which exist in several alternatives, and
+  you need them to call the command in the alternative of the
+  current flavor within an `%python_expand` block, this macro
+
+  - creates the appropriate update-alternatives symlinks in the
+    shuffled `build/flavorbin` directory and sets `$PATH`
+    accordingly, and
+  - selects the libalternatives priority of all installed commands
+    with a `libalternatives.conf` in
+    `XDG_CONFIG_HOME=$PWD/build/xdgflavorconfig`.
+
+  The `%pytest(_arch)` and `%pyunittest(_arch)` macros include a call
+  of this macro before expanding to the test suite execution.
 
 #### Flavor-specific macros  
 

--- a/macros/001-alternatives
+++ b/macros/001-alternatives
@@ -48,3 +48,29 @@ fi \
 %alternative_for() \
 %1 \
 %ghost %{_sysconfdir}/alternatives/%{basename:%1}
+
+%python_flavored_alternatives \
+%{python_expand # provide libalternatives and update-alternatives in the current flavor version when shuffling the build dir \
+mkdir -p build/xdgflavorconfig \
+export XDG_CONFIG_HOME=$PWD/build/xdgflavorconfig \
+if [ -d /usr/share/libalternatives/ ]; then \
+  for b in /usr/share/libalternatives/*; do \
+    if [ -e "${b}/%{$python_version_nodots}.conf" ]; then \
+        alts -n $(basename ${b}) -p %{$python_version_nodots} \
+    fi \
+  done \
+fi \
+mkdir -p build/flavorbin \
+for bin in %{_bindir}/*-%{$python_bin_suffix} %{buildroot}%{_bindir}/*-%{$python_bin_suffix}; do \
+  if [ -x "${bin}" ]; then \
+    # four percent into 1 by rpm/python expansions \
+    mainbin="${bin%%%%-%{$python_bin_suffix}}" \
+    basemain="$(basename ${mainbin})" \
+    if [ "$(readlink ${mainbin})" = "/etc/alternatives/${basemain}" ]; then \
+      ln -sf "${bin}" "build/flavorbin/${basemain}" \
+    fi \
+  fi \
+done \
+} \
+export PATH=$PWD/build/flavorbin:$PATH \
+%{nil}

--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -107,14 +107,18 @@
 
 ##### Python Unittest macros #####
 
-%pyunittest(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua:\
+%pyunittest(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) \
+%python_flavored_alternatives \
+%{lua:\
     local args = rpm.expand("%**"); \
     local broot = rpm.expand("%buildroot"); \
     local intro = "%{python_expand PYTHONPATH=${PYTHONPATH:+$PYTHONPATH:}" .. broot .. "%{$python_sitelib} PYTHONDONTWRITEBYTECODE=1 $python -m unittest "; \
     print(rpm.expand(intro .. args .. "}")) \
 }
 
-%pyunittest_arch(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua:\
+%pyunittest_arch(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) \
+%python_flavored_alternatives \
+%{lua:\
     local args = rpm.expand("%**"); \
     local broot = rpm.expand("%buildroot"); \
     local intro = "%{python_expand PYTHONPATH=${PYTHONPATH:+$PYTHONPATH:}" .. broot .. "%{$python_sitearch} PYTHONDONTWRITEBYTECODE=1 $python -m unittest "; \
@@ -123,7 +127,9 @@
 
 ##### Pytest macros #####
 
-%pytest(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua:\
+%pytest(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) \
+%python_flavored_alternatives \
+%{lua:\
     local args = rpm.expand("%**"); \
     local broot = rpm.expand("%buildroot"); \
     local intro = "%{python_expand PYTHONPATH=${PYTHONPATH:+$PYTHONPATH:}" .. broot .. "%{$python_sitelib} PYTHONDONTWRITEBYTECODE=1 "; \
@@ -132,7 +138,9 @@
     print(rpm.expand(intro .. args .. "}")) \
 }
 
-%pytest_arch(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua:\
+%pytest_arch(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) \
+%python_flavored_alternatives \
+%{lua:\
     local args = rpm.expand("%**"); \
     local broot = rpm.expand("%buildroot"); \
     local intro = "%{python_expand PYTHONPATH=${PYTHONPATH:+$PYTHONPATH:}" .. broot .. "%{$python_sitearch} PYTHONDONTWRITEBYTECODE=1 "; \


### PR DESCRIPTION
This came up in openSUSE/libalternatives#17 and might be handy for more packages.

Tested in [home:bnavigator:branches:devel:languages:python:jupyter](https://build.opensuse.org/project/show/home:bnavigator:branches:devel:languages:python:jupyter), where python-jupyter-server requires the correct alternative for a bunch of chained jupyter subcommands. Other packages in the project are not harmed by the addition.