### PR TITLE
Add "export" PYTHONPATH for the correct usage inside of the installation directory ( #124)

### DIFF
--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -126,7 +126,7 @@
 %pytest(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua:\
     local args = rpm.expand("%**"); \
     local broot = rpm.expand("%buildroot"); \
-    local intro = "%{python_expand PYTHONPATH=${PYTHONPATH:+$PYTHONPATH:}" .. broot .. "%{$python_sitelib} PYTHONDONTWRITEBYTECODE=1 "; \
+    local intro = "%{python_expand export PYTHONPATH=${PYTHONPATH:+$PYTHONPATH:}" .. broot .. "%{$python_sitelib} PYTHONDONTWRITEBYTECODE=1 "; \
     local ignore_build = "--ignore=_build." .. rpm.expand("%pythons"):gsub("%s+", " --ignore=_build."); \
     intro = intro .. "pytest-%{$python_bin_suffix} " .. ignore_build .. " -v "; \
     print(rpm.expand(intro .. args .. "}")) \
@@ -135,7 +135,7 @@
 %pytest_arch(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) %{lua:\
     local args = rpm.expand("%**"); \
     local broot = rpm.expand("%buildroot"); \
-    local intro = "%{python_expand PYTHONPATH=${PYTHONPATH:+$PYTHONPATH:}" .. broot .. "%{$python_sitearch} PYTHONDONTWRITEBYTECODE=1 "; \
+    local intro = "%{python_expand export PYTHONPATH=${PYTHONPATH:+$PYTHONPATH:}" .. broot .. "%{$python_sitearch} PYTHONDONTWRITEBYTECODE=1 "; \
     local ignore_build = "--ignore=_build." .. rpm.expand("%pythons"):gsub("%s+", " --ignore=_build."); \
     intro = intro .. "pytest-%{$python_bin_suffix} " .. ignore_build .. " -v "; \
     print(rpm.expand(intro .. args .. "}")) \


### PR DESCRIPTION
PYTHONPATH has been set at the moment but has not been exported. Therefore, some python tests can not find the installation directory with built modules by the package ( #124 ). In my case, I can not build python-zstandard because of this issue. The "export" has got the effect of the usage of the correct PYTHONPATH in pytest.