### PR TITLE
Avoid bashism in %()

### DIFF
--- a/flavor.in
+++ b/flavor.in
@@ -19,7 +19,7 @@
 %#FLAVOR#_provides %(provides=""; \
 for flavorbin in %{_bindir}/python?; do \
   if [ $flavorbin != %__#FLAVOR# -a $(realpath $flavorbin) = %__#FLAVOR# ]; then \
-    provides+=" $(basename $flavorbin)"; \
+    provides="$provides $(basename $flavorbin)"; \
   fi; \
 done; \
 echo ${provides# }; \


### PR DESCRIPTION
rpm is invokin this via the standard /bin/sh shell which might not
be bash. use POSIX shell constructs instead.