### PR TITLE
Update compile-macros.sh

### DIFF
--- a/compile-macros.sh
+++ b/compile-macros.sh
@@ -2,7 +2,7 @@
 
 # The set of flavors for which we produce macros. Not identical to
 # the buildset predefined for specific distributions (see below)
-FLAVORS="python2 python3 python36 python38 python39 python310 pypy3"
+FLAVORS="python2 python3 python38 python39 python310 python311 pypy3"
 
 ### flavor-specific: generate from flavor.in
 for flavor in $FLAVORS; do


### PR DESCRIPTION
python36 is dead, python311 beta is already in Factory

*This only produces the macros, it does not change the buildset*