### PR TITLE
restore end-of-line in alternative scriptlets

### DIFF
--- a/flavor.in
+++ b/flavor.in
@@ -62,16 +62,15 @@ end \
 # Commands for RPM scriptlets: These must not be empty even if there is no op for
 # either update-alternatives or libalternatives
 
-%#FLAVOR#_install_alternative() \
+%#FLAVOR#_install_alternative() \# #FLAVOR#_install_alternative: \
 %if ! %{with libalternatives} \
-%{_python_macro_init} \
-%{lua:python_install_ualternative("#FLAVOR#")} \
+%{_python_macro_init} %{lua:python_install_ualternative("#FLAVOR#")} \\\
 %else \
 : \# no install scriptlet action for libalternatives \
 %endif \
 %{nil}
 
-%#FLAVOR#_uninstall_alternative() \
+%#FLAVOR#_uninstall_alternative() \# #FLAVOR#_uninstall_alternative: \
 %if ! %{with libalternatives} \
 %{uninstall_alternative -n %1 -t %{_bindir}/%1-%#FLAVOR#_bin_suffix} \
 %else \
@@ -79,7 +78,7 @@ end \
 %endif \
 %{nil}
 
-%#FLAVOR#_reset_alternative() \
+%#FLAVOR#_reset_alternative() \# #FLAVOR#_reset_alternative: \
 %if %{with libalternatives} \
 %{reset_alternative -n %1 -t %{_bindir}/%1-%#FLAVOR#_bin_suffix} \
 %else \


### PR DESCRIPTION
fixes a regression from #135
(see https://build.opensuse.org/request/show/990548#comment-1654781)

home:bnavigator:python-rpm-macros/python-testpac-rpm-runtime:
```specfile
%pre
%python_libalternatives_reset_alternative testbin1
%python_libalternatives_reset_alternative testbin2

%post
%python_install_alternative testbinA
%{python_install_alternative testbinB} --slave /usr/bin/testbinC testbinC /usr/bin/testbinC-%{python_bin_suffix}
%{python_install_alternative testbin1 testbin2} \
  --slave /usr/bin/testbin3 testbin3 /usr/bin/testbin3-%{python_bin_suffix}
echo "another command"

%postun
%python_uninstall_alternative testbin1
echo "another command u"
```

```shell
> rpm -q --scripts /var/tmp/build-root/openSUSE_Tumbleweed-x86_64/home/abuild/rpmbuild/RPMS/noarch/python310-testpac-rpm-runtime-0.2-0.noarch.rpm
preinstall scriptlet (using /bin/sh):
# python310_reset_alternative: 
: # reset action only for libalternatives 

# python310_reset_alternative: 
: # reset action only for libalternatives
postinstall scriptlet (using /bin/sh):
# python310_install_alternative: 
 update-alternatives --quiet --install /usr/bin/testbinA testbinA /usr/bin/testbinA-3.10 1310 \

# python310_install_alternative: 
 update-alternatives --quiet --install /usr/bin/testbinB testbinB /usr/bin/testbinB-3.10 1310 \
 --slave /usr/bin/testbinC testbinC /usr/bin/testbinC-3.10
# python310_install_alternative: 
 update-alternatives --quiet --install /usr/bin/testbin1 testbin1 /usr/bin/testbin1-3.10 1310 \
   --slave /usr/bin/testbin2 testbin2 /usr/bin/testbin2-3.10 \
 \
  --slave /usr/bin/testbin3 testbin3 /usr/bin/testbin3-3.10
echo "another command"
postuninstall scriptlet (using /bin/sh):
# python310_uninstall_alternative: 

if [ ! -e "/usr/bin/testbin1-3.10" ]; then 
    update-alternatives --quiet --remove "testbin1" "/usr/bin/testbin1-3.10" 
fi 
 

echo "another command u"
```

