### PR TITLE
more compact alternative scriptlets without newline

### DIFF
--- a/flavor.in
+++ b/flavor.in
@@ -59,29 +59,17 @@ else \
 end \
 }
 
-# Commands for RPM scriptlets: These must not be empty even if there is no op for
-# either update-alternatives or libalternatives
+# Commands for RPM scriptlets: These must not be empty even if there is no operation for
+# either update-alternatives or libalternatives.
 
 %#FLAVOR#_install_alternative() \# #FLAVOR#_install_alternative: \
-%if ! %{with libalternatives} \
-%{_python_macro_init} %{lua:python_install_ualternative("#FLAVOR#")} \\\
-%else \
-: \# no install scriptlet action for libalternatives \
-%endif \
-%{nil}
+%{?!with_libalternatives:%{_python_macro_init}%{lua:python_install_ualternative("#FLAVOR#") \
+}}%{?with_libalternatives:\: \# no install scriptlet action for libalternatives}
 
 %#FLAVOR#_uninstall_alternative() \# #FLAVOR#_uninstall_alternative: \
-%if ! %{with libalternatives} \
-%{uninstall_alternative -n %1 -t %{_bindir}/%1-%#FLAVOR#_bin_suffix} \
-%else \
-: \# no uninstall scriptlet action for libalternatives \
-%endif \
-%{nil}
+%{?!with_libalternatives:%{uninstall_alternative -n %1 -t %{_bindir}/%1-%{#FLAVOR#_bin_suffix} \
+}}%{?with_libalternatives:\: \# no uninstall scriptlet action for libalternatives}
 
 %#FLAVOR#_reset_alternative() \# #FLAVOR#_reset_alternative: \
-%if %{with libalternatives} \
-%{reset_alternative -n %1 -t %{_bindir}/%1-%#FLAVOR#_bin_suffix} \
-%else \
-: \# reset action only for libalternatives \
-%endif \
-%{nil}
+%{?!with_libalternatives:\: \# reset action only for libalternatives \
+}%{?with_libalternatives:%{reset_alternative -n %1 -t %{_bindir}/%1-%{#FLAVOR#_bin_suffix}}}


### PR DESCRIPTION
Another take at #137
Attn @dirkmueller 

```specfile
%pre
%python_libalternatives_reset_alternative testbin1
%python_libalternatives_reset_alternative testbin2
%python_libalternatives_reset_alternative testbin4
echo "another command pre"

%post
%python_install_alternative testbin1
%python_install_alternative testbin2 testbin3
echo "inbetween command post"
%if ! %{with libalternatives}
%{python_install_alternative testbin4} \
  --slave /usr/bin/testbin-extra testbin-extra /usr/bin/testbin-extra-%{python_bin_suffix}
%endif
echo "another command post"

%postun
%python_uninstall_alternative testbin1
%python_uninstall_alternative testbin2
%python_uninstall_alternative testbin4
echo "another command postun"
```

without libalternatives:

```bash
ben@skylab:~/src/osc/home:bnavigator:python-rpm-macros/python-testpac-rpm-runtime> rpm -q --scripts /var/tmp/build-root/openSUSE_Tumbleweed-x86_64/home/abuild/rpmbuild/RPMS/noarch/python310-testpac-rpm-runtime-0.3-0.noarch.rpm
preinstall scriptlet (using /bin/sh):
# python310_reset_alternative testbin1: 
: # reset action only for libalternatives 

# python310_reset_alternative testbin2: 
: # reset action only for libalternatives 

# python310_reset_alternative testbin4: 
: # reset action only for libalternatives 

echo "another command pre"
postinstall scriptlet (using /bin/sh):
# python310_install_alternative testbin1: 
update-alternatives --quiet --install /usr/bin/testbin1 testbin1 /usr/bin/testbin1-3.10 1310
# python310_install_alternative testbin2 testbin3: 
update-alternatives --quiet --install /usr/bin/testbin2 testbin2 /usr/bin/testbin2-3.10 1310 \
   --slave /usr/bin/testbin3 testbin3 /usr/bin/testbin3-3.10
echo "inbetween command post"
# python310_install_alternative testbin4: 
update-alternatives --quiet --install /usr/bin/testbin4 testbin4 /usr/bin/testbin4-3.10 1310 \
  --slave /usr/bin/testbin-extra testbin-extra /usr/bin/testbin-extra-3.10
echo "another command post"
postuninstall scriptlet (using /bin/sh):
# python310_uninstall_alternative testbin1: 

if [ ! -e "/usr/bin/testbin1-3.10" ]; then 
    update-alternatives --quiet --remove "testbin1" "/usr/bin/testbin1-3.10" 
fi 

# python310_uninstall_alternative testbin2: 

if [ ! -e "/usr/bin/testbin2-3.10" ]; then 
    update-alternatives --quiet --remove "testbin2" "/usr/bin/testbin2-3.10" 
fi 

# python310_uninstall_alternative testbin4: 

if [ ! -e "/usr/bin/testbin4-3.10" ]; then 
    update-alternatives --quiet --remove "testbin4" "/usr/bin/testbin4-3.10" 
fi 

echo "another command postun"
```

with libalternatives:

```bash
ben@skylab:~/src/osc/home:bnavigator:python-rpm-macros/python-testpac-rpm-runtime> rpm -q --scripts /var/tmp/build-root/openSUSE_Tumbleweed-x86_64/home/abuild/rpmbuild/RPMS/noarch/python310-testpac-rpm-runtime-libalternatives-0.3-0.noarch.rpm
preinstall scriptlet (using /bin/sh):
# python310_reset_alternative testbin1: 

if [ "$1" -gt 0 ] && [ -f /usr/sbin/update-alternatives ]; then 
    update-alternatives --quiet --remove "testbin1" "/usr/bin/testbin1-3.10" 
fi 

# python310_reset_alternative testbin2: 

if [ "$1" -gt 0 ] && [ -f /usr/sbin/update-alternatives ]; then 
    update-alternatives --quiet --remove "testbin2" "/usr/bin/testbin2-3.10" 
fi 

# python310_reset_alternative testbin4: 

if [ "$1" -gt 0 ] && [ -f /usr/sbin/update-alternatives ]; then 
    update-alternatives --quiet --remove "testbin4" "/usr/bin/testbin4-3.10" 
fi 

echo "another command pre"
postinstall scriptlet (using /bin/sh):
# python310_install_alternative testbin1: 
: # no install scriptlet action for libalternatives
# python310_install_alternative testbin2 testbin3: 
: # no install scriptlet action for libalternatives
echo "inbetween command post"
echo "another command post"
postuninstall scriptlet (using /bin/sh):
# python310_uninstall_alternative testbin1: 
: # no uninstall scriptlet action for libalternatives
# python310_uninstall_alternative testbin2: 
: # no uninstall scriptlet action for libalternatives
# python310_uninstall_alternative testbin4: 
: # no uninstall scriptlet action for libalternatives
echo "another command postun"
```