### PR TITLE
fix double expanded compileall in %{$python_pyproject_install}

### DIFF
--- a/flavor.in
+++ b/flavor.in
@@ -81,7 +81,13 @@ if [ $havereq -eq 0 ]; then \
   done \
 fi \
 %__#FLAVOR# -mpip install %{pyproject_install_args} $myargs \
-%python_compileall
+for d in %{buildroot}%{#FLAVOR#_sitelib} %{buildroot}%{#FLAVOR#_sitearch}; do \
+  if [ -d $d ]; then \
+    find $d -name '*.pyc' -delete \
+    %__#FLAVOR# -m compileall $d \
+    %__#FLAVOR# -O -m compileall $d \
+  fi \
+done
 
 # Alternative entries in file section
 


### PR DESCRIPTION
The move of `%pyproject_install` from `%python_expand` to `flavor.in`, didn't consider the expansion of `%python_compileall`