### PR TITLE
Strip buildroot from pyc files

### DIFF
--- a/flavor.in
+++ b/flavor.in
@@ -86,8 +86,8 @@ fi \
 %#FLAVOR#_compile \
 for d in %{buildroot}%{#FLAVOR#_sitelib} %{buildroot}%{#FLAVOR#_sitearch}; do \
   if [ -d $d ]; then \
-    find $d -name '*.pyc' -delete \
-    find $d -iname '*.py' -exec %__#FLAVOR# -c \\\
+    find $d -iname '*.pyc' -delete \
+    find $d -iname '*.py' -printf 'Generating cached byte-code for %%P\\n' -exec %__#FLAVOR# -c \\\
        'import py_compile; f="{}"; [py_compile.compile(f, dfile=f[len("%{buildroot}"):], optimize=o) for o in [0, 1]]' ';' \
   fi \
 done

--- a/flavor.in
+++ b/flavor.in
@@ -81,11 +81,14 @@ if [ $havereq -eq 0 ]; then \
   done \
 fi \
 %__#FLAVOR# -mpip install %{pyproject_install_args} $myargs \
+%#FLAVOR#_compile
+
+%#FLAVOR#_compile \
 for d in %{buildroot}%{#FLAVOR#_sitelib} %{buildroot}%{#FLAVOR#_sitearch}; do \
   if [ -d $d ]; then \
     find $d -name '*.pyc' -delete \
-    %__#FLAVOR# -m compileall $d \
-    %__#FLAVOR# -O -m compileall $d \
+    find $d -iname '*.py' -exec %__#FLAVOR# -c \\\
+       'import py_compile; f="{}"; [py_compile.compile(f, dfile=f[len("%{buildroot}"):], optimize=o) for o in [0, 1]]' ';' \
   fi \
 done
 

--- a/macros.lua
+++ b/macros.lua
@@ -460,6 +460,13 @@ function pyproject_install(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ
     end
 end
 
+function python_compileall()
+    rpm.expand("%_python_macro_init")
+    for _, python in ipairs(pythons) do
+        print(rpm.expand("%" .. python .. "_compile"))
+    end
+end
+
 function python_files()
     rpm.expand("%_python_macro_init")
     local nparams = rpm.expand("%#")

--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -170,19 +170,6 @@
     print(rpm.expand(intro .. args .. "}")) \
 }
 
-##### Precompile scripts macro #####
-
-%python_compileall \
-%{python_expand for d in %{buildroot}%{$python_sitelib} %{buildroot}%{$python_sitearch}; do \
-  if [ -d $d ]; then \
-    find $d -name '*.pyc' -delete; \
-    $python -m compileall $d; \
-    $python -O -m compileall $d; \
-  fi; \
-done \
-} \
-%{nil}
-
 ##### Find language files #####
 
 %python_find_lang() \


### PR DESCRIPTION
Fixes #150, see discussion there.

We can't use the `-s` parameter of `python -m compileall`, because we need to stay compatible with Python <3.9 for the python38 flavor and Python 3.6 in 15.x.