### PR TITLE
Add python311 to buildset

### DIFF
--- a/default-prjconf
+++ b/default-prjconf
@@ -7,7 +7,7 @@
 ## PYTHON MACROS BEGIN
 # order of %pythons is important: The last flavor overrides any operation on conflicting files and definitions during expansions,
 # making it the "default" in many cases --> keep the primary python3 provider at the end.
-%pythons %{?!skip_python3:%{?!skip_python39:python39} %{?!skip_python38:python38} %{?!skip_python310:python310}}
+%pythons %{?!skip_python3:%{?!skip_python38:python38} %{?!skip_python39:python39} %{?!skip_python311:python311} %{?!skip_python310:python310}}
 %add_python() %{expand:%%define pythons %1 %pythons}
 
 %_without_python2 1


### PR DESCRIPTION
The [Tumbleweed prjconf](https://build.opensuse.org/projects/openSUSE:Factory/prjconf) has enabled python311 now. This must be reflected in the macros for pure rpmbuild builds.

It's also probably time to switch off python38 soon.