### PR TITLE
Add %<flavor>_fix_shebang macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,8 +384,13 @@ In addition, the following flavor-specific macros are known and supported by the
 
 * __`%<flavor>_install`__ expands to legacy `setup.py` install instructions for the particular flavor.
 
-* __`%<flavor>_sitelib`, `%<flavor>_sitearch`__: path to noarch and arch-dependent `site-packages`
-directory.
+* __`%<flavor>_fix_shebang`__ rewrites the script interpreter line in python scripts
+  installed into `%_bindir` to use the particular flavor. In multi-flavor expansions
+  the call of this macro is not required, as the script interpreter line is already
+  taken care of by the alternatives setup `%python_clone -a`.
+
+* __`%<flavor>_sitelib`, `%<flavor>_sitearch`__: path to noarch (purelib) and
+  arch-dependent `site-packages` (platlib) directory.
 
 * __`%<flavor>_version`__: dotted major.minor version. `2.7` for CPython 2.7.
 

--- a/flavor.in
+++ b/flavor.in
@@ -81,7 +81,8 @@ if [ $havereq -eq 0 ]; then \
   done \
 fi \
 %__#FLAVOR# -mpip install %{pyproject_install_args} $myargs \
-%#FLAVOR#_compile
+%#FLAVOR#_compile \
+%#FLAVOR#_fix_shebang
 
 %#FLAVOR#_compile \
 for d in %{buildroot}%{#FLAVOR#_sitelib} %{buildroot}%{#FLAVOR#_sitearch}; do \
@@ -90,6 +91,11 @@ for d in %{buildroot}%{#FLAVOR#_sitelib} %{buildroot}%{#FLAVOR#_sitearch}; do \
     find $d -iname '*.py' -printf 'Generating cached byte-code for %%P\\n' -exec %__#FLAVOR# -c \\\
        'import py_compile; f="{}"; [py_compile.compile(f, dfile=f[len("%{buildroot}"):], optimize=o) for o in [0, 1]]' ';' \
   fi \
+done
+
+%#FLAVOR#_fix_shebang \
+for f in %{buildroot}%{_bindir}/*; do \
+  [ -f $f ] && sed -i "1s@#!.*python.*@#!$(realpath %__#FLAVOR#)@" $f \
 done
 
 # Alternative entries in file section


### PR DESCRIPTION
As requested in #153 

This macro can be called explicitly as `%python310_fix_shebang`, if you want to have all scripts installed into `%_bindir` executed by `/usr/bin/python3.10`.

It is called implicitly in `%<flavor>_pyproject_install`, **but not in the deprecated `%<flavor>_install`.** The latter would require more effort to implement, because adding lines to the macro would prevent the common pattern to append arguments directly after the currently parameterless macro.

In a `%define pythons python3` build environment, `%python3_fix_shebang` creates the shebang with the resolved symlink where `%{_bindir}/python3` points to. This is the only use case where the macro makes sense. When installing entry-points, Pip and Setuptools normally create the interpreter lines with the same interpreter as they are called by. Thus `python3 setup.py install` (from `%python3_install`) or `python3 -mpip install ...` would create a shebang pointing to `python3`, but the macro fixes it to the current primary interpreter (`/usr/bin/python3.10`).