### PR TITLE
Support python-foo-py3 as multiflavor package name

### DIFF
--- a/macros.lua
+++ b/macros.lua
@@ -28,7 +28,13 @@ function _python_scan_spec()
     -- try to match "python-"
     if name == modname and name:find("python%-") == 1 then
         spec_name_prefix = "python"
-        modname = name:sub(8)
+
+        local suffix = name:find("%-py3")
+        if suffix then
+            modname = name:sub(8, suffix - 1)
+        else
+            modname = name:sub(8)
+        end
     end
     -- if not found, modname == %name, spec_name_prefix == "python"
 

--- a/macros.lua
+++ b/macros.lua
@@ -539,3 +539,13 @@ function python_module_lua()
         print(lpar .. python_prefix .. "-" .. string.gsub(params, "%%python", python_prefix) .. rpar .. " ")
     end
 end
+
+function name_without_py3_suffix()
+    local name = rpm.expand("%name")
+    local suffix = name:find("%-py3")
+    if suffix then
+        print(name:sub(0, suffix - 1))
+    else
+        print(name)
+    end
+end

--- a/macros.lua
+++ b/macros.lua
@@ -29,7 +29,8 @@ function _python_scan_spec()
     if name == modname and name:find("python%-") == 1 then
         spec_name_prefix = "python"
 
-        local suffix = name:find("%-py3")
+        -- Support packages with name python-foo-py3
+        local suffix = name:find("%-py%d+$")
         if suffix then
             modname = name:sub(8, suffix - 1)
         else
@@ -540,9 +541,9 @@ function python_module_lua()
     end
 end
 
-function name_without_py3_suffix()
+function name_without_pyX_suffix()
     local name = rpm.expand("%name")
-    local suffix = name:find("%-py3")
+    local suffix = name:find("%-py%d+$")
     if suffix then
         print(name:sub(0, suffix - 1))
     else


### PR DESCRIPTION
This PR adds the name format `python-FOO-py3` as a valid package name to generate `FOO` python package with the `%{python_subpackages}` macro and includes a new macro `%{name_without_py3_suffix}` to be able to use the generic package name in the spec file without the suffix.

This is useful to have multiple packages in the same project that generates the *same* python subpackages, but for different python versions, without source package name collision and being able to keep almost the same `.spec` file. For example:

 * python-FOO-py3: with `pythons python3`, will generate `python3-FOO` binary.
 * python-FOO: with `pythons python310 python311` will generate `python-310-FOO` and `python-311-FOO` binaries.