### PR TITLE
Speedup: Move compile loop to Python

### DIFF
--- a/flavor.in
+++ b/flavor.in
@@ -88,8 +88,14 @@ fi \
 for d in %{buildroot}%{#FLAVOR#_sitelib} %{buildroot}%{#FLAVOR#_sitearch}; do \
   if [ -d $d ]; then \
     find $d -iname '*.pyc' -delete \
-    find $d -iname '*.py' -printf 'Generating cached byte-code for %%P\\n' -exec %__#FLAVOR# -c \\\
-       'import py_compile; f="{}"; [py_compile.compile(f, dfile=f[len("%{buildroot}"):], optimize=o) for o in [0, 1]]' ';' \
+    find $d -iname '*.py' -print0 | xargs -0 %__#FLAVOR# -c ' \
+import sys, py_compile \
+for f in sys.argv[1:]: \
+  fp=f[len("%{buildroot}"):] \
+  print(f"Generating cached byte-code for {fp}") \
+  for o in [0, 1]: \
+    py_compile.compile(f, dfile=fp, optimize=o) \
+' \
   fi \
 done
 


### PR DESCRIPTION
The initially suggested solution for #150, implemented in #151, has impacted the build time of large python packages severely. Loading the python interpreter anew for the compilation of each source file takes a long time.

Let's move the loop into the interpreter process, so that it gets only loaded once and can use its import cache for all file compilations.

I checked the resulting `.pyc` files, there is no trace of glob order or contents of the `sys.argv[]` input to the script.

This improves the elapsed time spent for compiling the byte-code, e.g. for [plotly](https://build.opensuse.org/package/show/devel:languages:python:numeric/python-plotly) from *209 s* to *5 s* per flavor!