### PR TITLE
Fix shebang also in sbin with macro _fix_shebang

### DIFF
--- a/flavor.in
+++ b/flavor.in
@@ -102,6 +102,9 @@ done
 %#FLAVOR#_fix_shebang \
 for f in %{buildroot}%{_bindir}/*; do \
   [ -f $f ] && sed -i "1s@#!.*python.*@#!$(realpath %__#FLAVOR#)@" $f \
+done; \
+for f in %{buildroot}%{_sbindir}/*; do \
+  [ -f $f ] && sed -i "1s@#!.*python.*@#!$(realpath %__#FLAVOR#)@" $f \
 done
 
 # Alternative entries in file section


### PR DESCRIPTION
Some python scripts are installed in /usr/sbin, this patch makes the macro `%python3_fix_shebang` usable to fix also those scripts.