### PR TITLE
SPEC0: Drop python39, add python312 to buildset

### DIFF
--- a/compile-macros.sh
+++ b/compile-macros.sh
@@ -2,7 +2,7 @@
 
 # The set of flavors for which we produce macros. Not identical to
 # the buildset predefined for specific distributions (see below)
-FLAVORS="python2 python3 python310 python311 python312 pypy3"
+FLAVORS="python2 python3 python38 python39 python310 python311 python312 pypy3"
 
 ### flavor-specific: generate from flavor.in
 for flavor in $FLAVORS; do

--- a/compile-macros.sh
+++ b/compile-macros.sh
@@ -2,7 +2,7 @@
 
 # The set of flavors for which we produce macros. Not identical to
 # the buildset predefined for specific distributions (see below)
-FLAVORS="python2 python3 python38 python39 python310 python311 python312 pypy3"
+FLAVORS="python2 python3 python310 python311 python312 pypy3"
 
 ### flavor-specific: generate from flavor.in
 for flavor in $FLAVORS; do

--- a/default-prjconf
+++ b/default-prjconf
@@ -7,7 +7,7 @@
 ## PYTHON MACROS BEGIN
 # order of %pythons is important: The last flavor overrides any operation on conflicting files and definitions during expansions,
 # making it the "default" in many cases --> keep the primary python3 provider at the end.
-%pythons %{?!skip_python3:%{?!skip_python310:python310} %{?!skip_python311:python311}}
+%pythons %{?!skip_python3:%{?!skip_python310:python310} %{?!skip_python310:python312} %{?!skip_python311:python311}}
 %add_python() %{expand:%%define pythons %1 %pythons}
 
 %_without_python2 1

--- a/default-prjconf
+++ b/default-prjconf
@@ -7,7 +7,7 @@
 ## PYTHON MACROS BEGIN
 # order of %pythons is important: The last flavor overrides any operation on conflicting files and definitions during expansions,
 # making it the "default" in many cases --> keep the primary python3 provider at the end.
-%pythons %{?!skip_python3:%{?!skip_python39:python39} %{?!skip_python311:python311} %{?!skip_python310:python310}}
+%pythons %{?!skip_python3:%{?!skip_python310:python310} %{?!skip_python311:python311}}
 %add_python() %{expand:%%define pythons %1 %pythons}
 
 %_without_python2 1
@@ -19,5 +19,7 @@
 # pseudo-undefine for obs: reset for the next expansion within the next call of python_module
 %python_module_iter_STOP %global python %%%%python
 %python_module() %{?!python_module_lua:%{expand:%%define args %{**}} %{expand:%%{python_module_iter -a %{pythons} STOP}}}%{?python_module_lua:%python_module_lua %{**}}
+# gh#openSUSE/python-rpm-macros#127 ... define our current primary Python interpreter
+%primary_python python311
 ## PYTHON MACROS END
 # :Macros


### PR DESCRIPTION
The first packages in the scientific python stack are dropping  support for Python 3.9:

https://scientific-python.org/specs/spec-0000/

https://github.com/ipython/ipython/pull/14254

Let's not get into introducing `%define skip_python39 1` for every jupyter and d:l:p:n package.