### PR TITLE
Make sure that RPM_BUILD_ROOT env is set

### DIFF
--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -3,8 +3,8 @@
 
 ##### common functionality #####
 
-%_python_sysconfig_path() %([ -x %1 ] && %1 -c "import sysconfig as s; print(s.get_paths().get('%2'))" || echo "!!_{%1}_not_installed_!!")
-%_python_sysconfig_var()  %([ -x %1 ] && %1 -c "import sysconfig as s; print(s.get_config_var('%2'))"  || echo "!!_{%1}_not_installed_!!")
+%_python_sysconfig_path() %([ -x %1 ] && RPM_BUILD_ROOT="%{buildroot}" %1 -c "import sysconfig as s; print(s.get_paths().get('%2'))" || echo "!!_{%1}_not_installed_!!")
+%_python_sysconfig_var()  %([ -x %1 ] && RPM_BUILD_ROOT="%{buildroot}" %1 -c "import sysconfig as s; print(s.get_config_var('%2'))"  || echo "!!_{%1}_not_installed_!!")
 
 %_rec_macro_helper %{lua:
     rpm.define("_rec_macro_helper %{nil}")


### PR DESCRIPTION
The cpython patched returns the default paths based on /usr/local but for system packages it returns /usr when RPM_BUILD_ROOT variable is set.

https://src.fedoraproject.org/rpms/python3.12/blob/rawhide/f/00251-change-user-install-location.patch

Related opensuse bug: https://bugzilla.opensuse.org/show_bug.cgi?id=1225660