### PR TITLE
Fix python_clone sed regex

### DIFF
--- a/flavor.in
+++ b/flavor.in
@@ -111,7 +111,7 @@ done
 %#FLAVOR#_fix_shebang_path(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) \
 myargs="%{**}" \
 for f in ${myargs}; do \
-  [ -f $f ] && sed -i "1s@#\\!.*python\S*@#\\!$(realpath %__#FLAVOR#)@" $f \
+  [ -f $f ] && sed -i "1s@#\\!.*python\\S*@#\\!$(realpath %__#FLAVOR#)@" $f \
 done
 
 # Alternative entries in file section

--- a/macros.lua
+++ b/macros.lua
@@ -497,7 +497,7 @@ function python_clone(a)
         local binsuffix = rpm.expand("%" .. python .. "_bin_suffix")
         link,name,path = python_alternative_names(param, binsuffix, true)
         print(rpm.expand(string.format("cp %s %s\n", param, path)))
-        print(rpm.expand(string.format("sed -ri \"1s@#!.*python\S*@#!%s@\" %s\n", "$(realpath %__" .. python .. ")", path)))
+        print(rpm.expand(string.format("sed -ri \"1s@#!.*python\\S*@#!%s@\" %s\n", "$(realpath %__" .. python .. ")", path)))
     end
 
     -- %python_clone -a


### PR DESCRIPTION
Escape the `\S` correctly to fix the regular expression when using the python_clone macro:

```
error: invalid syntax in lua script: [string "python_clone"]:9: invalid escape sequence near '"sed -ri "1s@#!.*python\S'
```

https://build.opensuse.org/package/live_build_log/openSUSE:Factory:Staging:C/avahi/standard/x86_64