### PR TITLE
Add %FLAVOR_pytest and %FLAVOR_pyunittest variants

### DIFF
--- a/flavor.in
+++ b/flavor.in
@@ -44,6 +44,26 @@ myargs="%{**}" \
 %#FLAVOR#_compile \
 %#FLAVOR#_fix_shebang
 
+%#FLAVOR#_pytest(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) \
+%{_python_use_flavor #FLAVOR#} \
+myargs="%{**}" \
+PYTHONPATH=${PYTHONPATH:+$PYTHONPATH:}%{buildroot}%{#FLAVOR#_sitelib} PYTHONDONTWRITEBYTECODE=1 %__#FLAVOR# -m pytest -v $myargs
+
+%#FLAVOR#_pytest_arch(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) \
+%{_python_use_flavor #FLAVOR#} \
+myargs="%{**}" \
+PYTHONPATH=${PYTHONPATH:+$PYTHONPATH:}%{buildroot}%{#FLAVOR#_sitearch} PYTHONDONTWRITEBYTECODE=1 %__#FLAVOR# -m pytest -v $myargs
+
+%#FLAVOR#_pyunittest(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) \
+%{_python_use_flavor #FLAVOR#} \
+myargs="%{**}" \
+PYTHONPATH=${PYTHONPATH:+$PYTHONPATH:}%{buildroot}%{#FLAVOR#_sitelib} PYTHONDONTWRITEBYTECODE=1 %__#FLAVOR# -m unittest $myargs
+
+%#FLAVOR#_pyunittest_arch(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) \
+%{_python_use_flavor #FLAVOR#} \
+myargs="%{**}" \
+PYTHONPATH=${PYTHONPATH:+$PYTHONPATH:}%{buildroot}%{#FLAVOR#_sitearch} PYTHONDONTWRITEBYTECODE=1 %__#FLAVOR# -m unittest $myargs
+
 ##### PEP517/PEP518 macros #####
 
 %#FLAVOR#_pyproject_wheel(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) \


### PR DESCRIPTION
This patch adds new flavored macros for pytest and pyunittest, so it's possible to use this macro without using subpackages, usually as %python3_pytest.

Fix https://github.com/openSUSE/python-rpm-macros/issues/170