### PR TITLE
Follow symlinks when replacing shebang with sed

### DIFF
--- a/flavor.in
+++ b/flavor.in
@@ -131,7 +131,7 @@ done
 %#FLAVOR#_fix_shebang_path(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) \
 myargs="%{**}" \
 for f in ${myargs}; do \
-  [ -f "$f" -a  -x "$f" ] && sed -i "1s@#\\!.*python\\S*@#\\!$(realpath %__#FLAVOR#)@" "$f" \
+  [ -f "$f" -a  -x "$f" ] && sed -i --follow-symlinks "1s@#\\!.*python\\S*@#\\!$(realpath %__#FLAVOR#)@" "$f" \
 done
 
 # Alternative entries in file section


### PR DESCRIPTION
`sed -i` breaks links, even if it's not replacing anything, so the usage of this script breaks all links in `/usr/bin` and `/usr/sbin` creating a copy of the files.

The `--follow-symlinks` options fixes this issue with `sed` so symlinks will be preserved.