### PR TITLE
Do not fix shebang on links to non-writeable files

### DIFF
--- a/flavor.in
+++ b/flavor.in
@@ -131,7 +131,7 @@ done
 %#FLAVOR#_fix_shebang_path(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) \
 myargs="%{**}" \
 for f in ${myargs}; do \
-  [ -f "$f" -a  -x "$f" ] && sed -i --follow-symlinks "1s@#\\!.*python\\S*@#\\!$(realpath %__#FLAVOR#)@" "$f" \
+  [ -f "$f" -a  -x "$f" -a -w "$f" ] && sed -i --follow-symlinks "1s@#\\!.*python\\S*@#\\!$(realpath %__#FLAVOR#)@" "$f" \
 done
 
 # Alternative entries in file section


### PR DESCRIPTION
Following a symlink out of %(buildroot} can't possibly work, this patch just try to fix shebang in files that are writeable by the user.

See https://github.com/openSUSE/python-rpm-macros/pull/186#issuecomment-2483420359