### PR TITLE
Drop python38, add python314

### DIFF
--- a/compile-macros.sh
+++ b/compile-macros.sh
@@ -2,7 +2,7 @@
 
 # The set of flavors for which we produce macros. Not identical to
 # the buildset predefined for specific distributions (see below)
-FLAVORS="python2 python3 python38 python39 python310 python311 python312 python313 pypy3"
+FLAVORS="python2 python3 python39 python310 python311 python312 python313 python314 pypy3"
 
 ### flavor-specific: generate from flavor.in
 for flavor in $FLAVORS; do


### PR DESCRIPTION
python 3.8 is not used in any maintained distribution anymore. 3.14 is being introduced in Factory.