### PR TITLE
Remove pip --build-option and %py_setup_args

### DIFF
--- a/flavor.in
+++ b/flavor.in
@@ -33,13 +33,13 @@ echo ${provides# }; \
 
 %#FLAVOR#_build \
 %{_python_use_flavor #FLAVOR#} \
-%__#FLAVOR# %{py_setup} %{?py_setup_args} build \\\
+%__#FLAVOR# %{py_setup} build \\\
     --executable="%__#FLAVOR# %#FLAVOR#_shbang_opts"
 
 %#FLAVOR#_install(+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) \
 %{_python_use_flavor #FLAVOR#} \
 myargs="%{**}" \
-%__#FLAVOR# %{py_setup} %{?py_setup_args} install \\\
+%__#FLAVOR# %{py_setup} install \\\
     -O1 --skip-build --force --root %{buildroot} --prefix %{_prefix} $myargs \
 %#FLAVOR#_compile \
 %#FLAVOR#_fix_shebang

--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -23,7 +23,6 @@
 
 %pyproject_wheel_args \\\
   --verbose --progress-bar off --disable-pip-version-check \\\
-  %{?py_setup_args:--build-option %{py_setup_args}} \\\
   --use-pep517 --no-build-isolation \\\
   --no-deps \\\
   --wheel-dir %{_pyproject_wheeldir}


### PR DESCRIPTION
--build-option and --global-option are deprecated. A possible replacement is to use --config-settings. Discussion can be found at gh#pypa/pip#11859