### PR TITLE
Add initial pyproject declarative buildsystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,6 +577,45 @@ See also the Filelists section of the
 [openSUSE:Packaging Python](https://en.opensuse.org/openSUSE:Packaging_Python#Filelists)
 guidelines
 
+### Declarative build system
+
+The macros defines a new [buildsystem](https://rpm-software-management.github.io/rpm/manual/buildsystem.html)
+to use for python packaging.
+
+You can use the `pyproject` buildsystem in your spec file to simplify:
+
+```
+BuildSystem: pyproject
+```
+
+This buildsystem defines the `%build`, `%install` and `%check`
+sections with default calls to `%pyproject_wheel`,
+`%pyproject_install` and `%pytest`.
+
+These sections can be extended using `-a` to append or `-p` to prepend
+commands, or completely overwritten using the default tag.
+
+```
+# Extend prep
+%prep -a
+rm -rf not-needed-file
+
+# Extend build prepending commands
+%build -p
+export CFLAGS="$CFLAGS -g"
+
+# Extend install
+%install -a
+%python_clone -a %{buildroot}/%{_bindir}/cmd1
+%python_clone -a %{buildroot}/%{_binddir}/cmd2
+%python_clone -a %{buildroot}/%{_mandir}/man1/cmd1.1
+%python_group_libalternatives cmd1 cmd2
+
+# Replace default check
+%check
+%pytest_arch -k "network"
+```
+
 ### Files in Repository
 
 #### `macros` directory

--- a/macros/060-buildsystem
+++ b/macros/060-buildsystem
@@ -1,0 +1,7 @@
+# Declarative buildsystem, requires RPM 4.20+ to work
+# https://rpm-software-management.github.io/rpm/manual/buildsystem.html
+%buildsystem_pyproject_conf() %nil
+%buildsystem_pyproject_build() %pyproject_wheel %*
+%buildsystem_pyproject_install() %pyproject_install %*
+%buildsystem_pyproject_check() %pytest %*
+%buildsystem_pyproject_generate_buildrequires() %{nil}

--- a/testfiles/declarative.spec
+++ b/testfiles/declarative.spec
@@ -1,0 +1,49 @@
+#
+# spec file for package declarative-01
+#
+# Copyright (c) 2025 SUSE LLC and contributors
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
+%bcond_without libalternatives
+Name:           declarative
+Version:        1.0
+Release:        0
+Summary:        Declarative
+License:        MIT
+URL:            http://example.com
+Source0:        declarative.tar.gz
+BuildRequires:  python-rpm-macros
+BuildRequires:  pytest
+BuildRequires:  alts
+Requires:       alts
+
+BuildSystem:    pyproject
+
+%python_subpackages
+
+%description
+Declarative test
+
+%install -a
+%python_clone -a %{buildroot}/%{_bindir}/cmd1
+
+%files %{python_files}
+%license LICENSE
+%doc README.md
+%python_alternative %{_bindir}/cmd1
+%{python_sitelib}/test
+%{python_sitelib}/test-%{version}*-info
+
+%changelog
+


### PR DESCRIPTION
This change adds the buildsystem pyproject to be used with rpm >= 4.20 declarative spec files. The new testfiles/declarative.spec shows an example file using this buildsystem.