### PR TITLE
Support Python module names with a custom prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ build set of Tumbleweed and SLE/Leap >= 15.4)
 Skip-macros are intended __for per-package use only__. Never define a skip-macro in prjconf or
 in any other sort of global config. Instead, redefine `%pythons`.
 
+You can define a custom prefix for your Python package by defining the __`%python_module_prefix`__
+macro.
+
 ### Macros
 
 The following macros are considered public API:
@@ -100,6 +103,11 @@ other files in non-flavor-specific locations. By default, set to `python3`.
   `%python` for expansion of the python-flavor within the requirement, e.g.
   `BuildRequires: %{python_module python-aiocontextvars >= 0.2.2 if %python-base < 3.7}`.
   (Don't define `%python` anywhere else.)
+
+* __`%{prefixed_python_module modname args}`__ expands to `(%{?python_module_prefix}<flavor>-modname args)`
+  for every flavor. Works in the same way as `%{python_module modname args}` but prepending a custom
+  package prefix via the `python_module_prefix` macro, which can be defined in the spec file or globally.
+  Intended as: `BuildRequires: %{prefixed_python_module foo >= version}`.
 
 * __`%{python_dist_name modname}`__. Given a standardized name (i.e. dist name, name on PyPI) of `modname`,
 it will convert it to a canonical format.

--- a/default-prjconf
+++ b/default-prjconf
@@ -19,6 +19,11 @@
 # pseudo-undefine for obs: reset for the next expansion within the next call of python_module
 %python_module_iter_STOP %global python %%%%python
 %python_module() %{?!python_module_lua:%{expand:%%define args %{**}} %{expand:%%{python_module_iter -a %{pythons} STOP}}}%{?python_module_lua:%python_module_lua %{**}}
+# Define a similar method to 'python_module' which includes a prefix in the package name via the 'python_module_prefix' macro
+%prefixed_python_module_iter(a:) %{expand:%%define python %{-a*}} ( %{?python_module_prefix}%python-%args ) %{expand:%%{?!prefixed_python_module_iter_%1:%%{prefixed_python_module_iter -a%*}}%%{?prefixed_python_module_iter_%1}}
+# pseudo-undefine for obs: reset for the next expansion within the next call of python_module
+%prefixed_python_module_iter_STOP %global python %%%%python
+%prefixed_python_module() %{?!prefixed_python_module_lua:%{expand:%%define args %{**}} %{expand:%%{prefixed_python_module_iter -a %{pythons} STOP}}}%{?prefixed_python_module_lua:%prefixed_python_module_lua %{**}}
 # gh#openSUSE/python-rpm-macros#127 ... define our current primary Python interpreter
 %primary_python python313
 ## PYTHON MACROS END

--- a/functions.lua
+++ b/functions.lua
@@ -59,7 +59,7 @@ function package_name(flavor, modname, subpkg, append)
     if flavor == "python2" and old_python2 then
         flavor = "python"
     end
-    local name = flavor .. "-" .. modname
+    local name = rpm.expand("%{?python_module_prefix}") .. flavor .. "-" .. modname
     if subpkg and subpkg ~= "" then
         name = name .. "-" .. subpkg
     end

--- a/macros.lua
+++ b/macros.lua
@@ -533,3 +533,25 @@ function python_module_lua()
         print(lpar .. python_prefix .. "-" .. string.gsub(params, "%%python", python_prefix) .. rpar .. " ")
     end
 end
+
+-- called by %prefixed_python_module, see buildset.in
+function prefixed_python_module_lua()
+    local python_module_prefix = rpm.expand("%{?python_module_prefix}")
+    rpm.expand("%_python_macro_init")
+    local params = rpm.expand("%**")
+    -- The Provides: tag does not support boolean dependencies, so only add parens if needed
+    local lpar = ""
+    local rpar = ""
+    local OPERATORS = lookup_table { 'and', 'or', 'if', 'with', 'without', 'unless'}
+    for p in string.gmatch(params, "%S+") do
+        if OPERATORS[p] then
+            lpar = "("
+            rpar = ")"
+            break
+        end
+    end
+    for _, python in ipairs(pythons) do
+        local python_prefix = rpm.expand("%" .. python .. "_prefix")
+        print(lpar .. python_module_prefix .. python_prefix .. "-" .. string.gsub(params, "%%python", python_prefix) .. rpar .. " ")
+    end
+end


### PR DESCRIPTION
Fixes #202 

This contribution implements support for defining Python modules with a custom prefix, which can be defined per-spec or globally at project-level via the `%python_module_prefix` macro.

It also adds support for a `%{prefixed_python_module modname args}` macro which is expected to work in the same way as `%{python_module modname args}`, with the exception of also taking into account the prefix defined in the `%python_module_prefix` macro.