### PR TITLE
Definitions of %python_site{lib,arch}_module macros.

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,18 @@ one applies for `uninstall_alternative`.
 
 Each of these has a flavor-specific spelling: `%python2_alternative` etc.
 
+#### %python_sitelib_module and %python_sitearch_module
+
+Generates paths for module and *-info directory in `%files` sections of
+SPEC files.
+
+Use `%python_sitearch_module` instead of
+
+```spec
+%{python_sitearch}/foo
+%{python_sitearch}/foo-%{version}*-info
+```
+
 
 ### Libalternatives-related:
 

--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -76,6 +76,10 @@
                 name = rpm.expand("%{?name:%{name}}");\
             end\
         end\
+        if (name == nil or name == "") then\
+            rpm.expand("%{error:failed to determine module/dist name}");\
+            return;\
+        end\
         meta_name = string.gsub(string.lower(name), "[-_.]+", "_");\
         print(name .. " " .. meta_name);\
     }

--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -68,6 +68,17 @@
 # this is by convention hardcoded python2
 %py_ver  %(python -c "import sys; v=sys.version_info[:2]; print '%%d.%%d'%%v" 2>/dev/null || echo PYTHON-NOT-FOUND)
 
+%python_sitelib_module() %{lua:\
+        name = rpm.expand("%{?1:%{1}}");\
+        print("%{python_sitelib}/" .. name .."\n" .. "%{python_sitelib}/" .. name .. "-%{version}*-info");\
+}
+
+%python_sitearch_module() %{lua:\
+        name = rpm.expand("%{?1:%{1}}");\
+        print("%{python_sitearch}/" .. name .."\n" .. "%{python_sitearch}/" .. name .. "-%{version}*-info");\
+}
+
+
 ##### Python dependency generator macros #####
 
 # === Macros for Build/Requires tags using Python dist tags ===

--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -70,12 +70,14 @@
 
 %python_sitelib_module() %{lua:\
         name = rpm.expand("%{?1:%{1}}");\
-        print("%{python_sitelib}/" .. name .."\n" .. "%{python_sitelib}/" .. name .. "-%{version}*-info");\
+        meta_name = string.gsub(name, "[-_.]+", "_");\
+        print("%{python_sitelib}/" .. name .."\n" .. "%{python_sitelib}/" .. meta_name .. "-%{version}*-info");\
 }
 
 %python_sitearch_module() %{lua:\
         name = rpm.expand("%{?1:%{1}}");\
-        print("%{python_sitearch}/" .. name .."\n" .. "%{python_sitearch}/" .. name .. "-%{version}*-info");\
+        meta_name = string.gsub(name, "[-_.]+", "_");\
+        print("%{python_sitearch}/" .. name .."\n" .. "%{python_sitearch}/" .. meta_name .. "-%{version}*-info");\
 }
 
 

--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -68,17 +68,35 @@
 # this is by convention hardcoded python2
 %py_ver  %(python -c "import sys; v=sys.version_info[:2]; print '%%d.%%d'%%v" 2>/dev/null || echo PYTHON-NOT-FOUND)
 
-%python_sitelib_module() %{lua:\
+%__python_sitedir_name() %{lua:\
         name = rpm.expand("%{?1:%{1}}");\
-        meta_name = string.gsub(name, "[-_.]+", "_");\
-        print("%{python_sitelib}/" .. name .."\n" .. "%{python_sitelib}/" .. meta_name .. "-%{version}*-info");\
-}
+        if (name == nil or name == "") then\
+            name = rpm.expand("%{?mod_name:%{mod_name}}");\
+            if (name == nil or name == "") then\
+                name = rpm.expand("%{?name:%{name}}");\
+            end\
+        end\
+        meta_name = string.gsub(string.lower(name), "[-_.]+", "_");\
+        print(name .. " " .. meta_name);\
+    }
+
+%python_sitelib_module() %{lua:\
+        res = rpm.expand("%__python_sitedir_name %{?1}");\
+        name, meta_name = res:match("(%S+) (%S+)");\
+        sitedir = rpm.expand("%{python_sitelib}");\
+        version = rpm.expand("%{version}");\
+        print(sitedir .. "/" .. name .. string.char(10));\
+        print(sitedir .. "/" .. meta_name .. "-" .. version .. "*-info");\
+    }
 
 %python_sitearch_module() %{lua:\
-        name = rpm.expand("%{?1:%{1}}");\
-        meta_name = string.gsub(name, "[-_.]+", "_");\
-        print("%{python_sitearch}/" .. name .."\n" .. "%{python_sitearch}/" .. meta_name .. "-%{version}*-info");\
-}
+        res = rpm.expand("%__python_sitedir_name %{?1}");\
+        name, meta_name = res:match("(%S+) (%S+)");\
+        sitedir = rpm.expand("%{python_sitearch}");\
+        version = rpm.expand("%{version}");\
+        print(sitedir .. "/" .. name .. string.char(10));\
+        print(sitedir .. "/" .. meta_name .. "-" .. version .. "*-info");\
+    }
 
 
 ##### Python dependency generator macros #####


### PR DESCRIPTION
I think it could make our life easier, and it could help to break the bad habit of `%{python_sitelib}/*`.