### PR TITLE
Update python version handling in default-prjconf

### DIFF
--- a/default-prjconf
+++ b/default-prjconf
@@ -7,7 +7,7 @@
 ## PYTHON MACROS BEGIN
 # order of %pythons is important: The last flavor overrides any operation on conflicting files and definitions during expansions,
 # making it the "default" in many cases --> keep the primary python3 provider at the end.
-%pythons %{?!skip_python3:%{?!skip_python311:python311} %{?!skip_python312:python312} %{?!skip_python313:python313}}
+%pythons %{?!skip_python3:%{?!skip_python311:python311} %{?!skip_python314:python314} %{?!skip_python313:python313}}
 %add_python() %{expand:%%define pythons %1 %pythons}
 
 %_without_python2 1


### PR DESCRIPTION
The current definition at https://build.opensuse.org/projects/openSUSE:Factory/prjconf Line 3732 has python314, we are out of date here.