### PR TITLE
Add %python_test macro and use in declarative build system

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,43 @@ It is the same as the above, except it sets ``$PYTHONPATH`` to
 It runs `$python -m unittest` on all flavors with
 appropriate environmental variables very similar to `%pytest` and `%pytest_arch`.
 
+#### `%python_test`
+
+Generic test macro, it runs the tool provided by the
+`%python_test_engine`, that's `%pyunittest` by default. to use
+`%pytest` you can set the `%python_test_engine` to "pytest".
+
+This macro adds the `_arch` suffix when `%_arch == "noarch"`
+automatically, so there's no need for `_arch` variants.
+
+For example:
+
+```
+%python_test -v tests/test_something.py
+```
+
+Will be transformed (in a package with BuildArch: noarch):
+
+```
+%pyunittest -v tests/test_something.py
+```
+
+or (with BuildArch: noarch):
+
+```
+%pyunittest_arch -v tests/test_something.py
+```
+
+And to get the same thing with pytest:
+
+```
+%global python_test_engine "pytest"
+%python_test tests/test_something.py -k "not test"
+```
+
+```
+%pytest tests/test_something.py -k "not test"
+```
 
 ### Alternative-related, general:
 
@@ -603,7 +640,7 @@ BuildSystem: pyproject
 
 This buildsystem defines the `%build`, `%install` and `%check`
 sections with default calls to `%pyproject_wheel`,
-`%pyproject_install` and `%pytest`.
+`%pyproject_install` and [`%python_test`](#python_test).
 
 These sections can be extended using `-a` to append or `-p` to prepend
 commands, or completely overwritten using the default tag.
@@ -628,6 +665,17 @@ export CFLAGS="$CFLAGS -g"
 %check
 %pytest_arch -k "network"
 ```
+
+Tests can be configured with BuildOptions, for example:
+```
+%global python_test_engine "pytest"
+BuildOption(check): -k "not test"
+```
+
+By default all BuildOptions for the check section will be forwarded to
+the `%pyunittest` macro. To use pytest just set the
+`%python_test_engine` macro and add the rest of the parameters for the
+`%pytest` macro in the BuildOption.
 
 ### Files in Repository
 

--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -206,6 +206,23 @@
     print(rpm.expand(intro .. args .. "}")) \
 }
 
+##### Generic python_test macro #####
+# It uses the value defined in %python_test_engine that the user can
+# override
+%python_test_engine pyunittest
+
+%python_test(abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-=) \
+%python_flavored_alternatives \
+%{lua:\
+    local test_module = rpm.expand("%python_test_engine"); \
+    local arch = rpm.expand("%_arch"); \
+    local args = rpm.expand("%**"); \
+    if (arch ~= "noarch") then \
+      test_module = test_module .. "_arch"; \
+    end \
+    print(rpm.expand("%" .. test_module .. " " .. args)) \
+}
+
 ##### Find language files #####
 
 %python_find_lang() \

--- a/macros/060-buildsystem
+++ b/macros/060-buildsystem
@@ -3,5 +3,7 @@
 %buildsystem_pyproject_conf() %nil
 %buildsystem_pyproject_build() %pyproject_wheel %*
 %buildsystem_pyproject_install() %pyproject_install %*
-%buildsystem_pyproject_check() %pytest %*
+# Allow usage of other test macros
+# BuildOption(check): -k "not test"
+%buildsystem_pyproject_check() %python_test %*
 %buildsystem_pyproject_generate_buildrequires() %{nil}

--- a/testfiles/declarative.spec
+++ b/testfiles/declarative.spec
@@ -27,7 +27,9 @@ BuildRequires:  python-rpm-macros
 BuildRequires:  pytest
 BuildRequires:  alts
 Requires:       alts
-
+BuildArch:      noarch
+%global python_test_engine pytest
+BuildOption(check): -k "not test"
 BuildSystem:    pyproject
 
 %python_subpackages


### PR DESCRIPTION
This patch adds a new %python_test macro that just calls %pyunittest or %pyunittest_arch depending on the value of %_arch. This new macro also accepts the --pytest parameter to use the %pytest macro instead with the same arch/noarch behavior.

This macro is used by default in the declarative macros so the default dependency on python-pytest is removed. Right now by default it will use %pyunittest macro and it's possible to change the behavior without replacing the %check section completely but using BuildOption(check):

BuildOption(check): --pytest -k "not test"