### PR TITLE
Add default primary_python definition

### DIFF
--- a/macros/010-common-defs
+++ b/macros/010-common-defs
@@ -1,5 +1,6 @@
 %system_python python2
 %python_for_executables python3
+%primary_python python3
 
 ##### common functionality #####
 


### PR DESCRIPTION
After the inclussion of "Use the primary interpreter for generic python3 macros" commit ([08c5ec8da9157ba4621c71c6544b1b1c2a75d296a](https://github.com/openSUSE/python-rpm-macros/commit/08c5ec8da9157ba4621c71c6544b1b1c2a75d296)), the primary_python macro is needed, so we need a fallback for projects that doesn't define it.

This will be overriten by the project definition in the compile-macros.sh script that generates the macros/041-buildset, so this definition should be transparent for Factory and SLE 16 projects.